### PR TITLE
Fix closing sidebar submenus

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -74,6 +74,13 @@ export function AppSidebar({ activeModule, onModuleChange }: AppSidebarProps) {
 
   const isExpanded = isHovered;
 
+  // Collapse any open groups when the sidebar collapses
+  useEffect(() => {
+    if (!isExpanded) {
+      setExpandedGroups([]);
+    }
+  }, [isExpanded]);
+
   const toggleGroup = (groupId: string) => {
     setExpandedGroups(prev => 
       prev.includes(groupId) 

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -93,6 +93,8 @@ export function AppSidebar({ activeModule, onModuleChange }: AppSidebarProps) {
       onMouseLeave={() => {
         if (hoverTimeout) clearTimeout(hoverTimeout);
         setIsHovered(false);
+        // Collapse all expanded groups when the sidebar closes
+        setExpandedGroups([]);
       }}
     >
       <div className="flex flex-col h-full">


### PR DESCRIPTION
## Summary
- collapse expanded sidebar groups when the sidebar closes

## Testing
- `npm run lint` *(fails: prefer-const, no-explicit-any, no-require-imports)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687bd41a5fe0832cae51f76db2387e2a