### PR TITLE
Fix useEffect import in AppSidebar

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { 
   TrendingUp, 
   Users, 


### PR DESCRIPTION
## Summary
- import `useEffect` in `AppSidebar`

## Testing
- `npm run lint` *(fails: ESLint config not found)*
- `npm install` *(fails: network error ECONNRESET)*

------
https://chatgpt.com/codex/tasks/task_e_687cfd5b41b0832cbe75cc5a26ad236d