### PR TITLE
Fix JSX closing in ProjectModule

### DIFF
--- a/src/components/ProjectModule.tsx
+++ b/src/components/ProjectModule.tsx
@@ -308,7 +308,8 @@ const ProjectModule = () => {
                 </div>
               </CardContent>
             </Card>
-          ))}
+            );
+          })}
 
           <Card>
             <CardHeader><CardTitle>Verzögerte Projekte</CardTitle></CardHeader>


### PR DESCRIPTION
## Summary
- close the return statement in `ProjectModule` when mapping over projects

## Testing
- `npx eslint src/components/ProjectModule.tsx`

------
https://chatgpt.com/codex/tasks/task_e_687f63713ac0832cb8f4c7efd7bf95eb