### PR TITLE
Update README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ cd <YOUR_PROJECT_NAME>
 
 # Step 3: Install the necessary dependencies.
 npm i
+# Run this before using `npm run build` or `npm run preview`.
 
 # Step 4: Start the development server with auto-reloading and an instant preview.
 npm run dev


### PR DESCRIPTION
## Summary
- clarify that `npm install` is required before running build or preview

## Testing
- `npm install`
- `npm run build` *(fails: Expected ";" but found ")")*
- `npm run lint` *(fails: 53 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687f63736bcc832cab1b0d2f1b051911