### PR TITLE
Fix progress bar handling for missing project end dates

### DIFF
--- a/src/components/ProjectModule.tsx
+++ b/src/components/ProjectModule.tsx
@@ -269,6 +269,9 @@ const ProjectModule = () => {
                   
                   <div className="flex space-x-1 mb-4">
                     {(() => {
+                      if (!project.end_date) {
+                        return null;
+                      }
                       const start = new Date(project.start_date);
                       const end = new Date(project.end_date);
                       const totalDays = Math.ceil((end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24)) + 1;
@@ -307,8 +310,9 @@ const ProjectModule = () => {
                   </Button>
                 </div>
               </CardContent>
-            </Card>
-          ))}
+              </Card>
+            );
+          })}
 
           <Card>
             <CardHeader><CardTitle>Verzögerte Projekte</CardTitle></CardHeader>


### PR DESCRIPTION
## Summary
- avoid progress calculation when `end_date` is absent
- clean up JSX to close the progress card mapping correctly

## Testing
- `npm run lint` *(fails: 75 problems)*

------
https://chatgpt.com/codex/tasks/task_e_687f637260b8832cae2dcf325e4241ab