### PR TITLE
Modify edit customer dialog size

### DIFF
--- a/src/components/EditCustomerDialog.tsx
+++ b/src/components/EditCustomerDialog.tsx
@@ -164,7 +164,7 @@ const EditCustomerDialog = ({ isOpen, onClose, customer, onCustomerUpdated }: Ed
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-6xl max-h-[95vh] overflow-y-auto">
+      <DialogContent className="max-w-7xl h-[95vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Kunde bearbeiten</DialogTitle>
           <DialogDescription>


### PR DESCRIPTION
## Summary
- keep customer edit dialog a consistent height
- widen dialog for easier editing

## Testing
- `npm run lint` *(fails: 52 errors, 23 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687f7ddd0568832cb87d7a377464c06b