### PR TITLE
Check RESEND_API_KEY in email functions

### DIFF
--- a/supabase/functions/send-document-email/index.ts
+++ b/supabase/functions/send-document-email/index.ts
@@ -2,8 +2,6 @@ import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { Resend } from "npm:resend@2.0.0";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
-const resend = new Resend(Deno.env.get("RESEND_API_KEY"));
-
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Headers":
@@ -26,10 +24,24 @@ const handler = async (req: Request): Promise<Response> => {
   }
 
   try {
-    const { 
-      documentType, 
-      documentId, 
-      recipientEmail, 
+    const apiKey = Deno.env.get("RESEND_API_KEY");
+    if (!apiKey) {
+      const message = "Missing RESEND_API_KEY configuration";
+      console.error(message);
+      return new Response(
+        JSON.stringify({ success: false, error: message }),
+        {
+          status: 500,
+          headers: { "Content-Type": "application/json", ...corsHeaders },
+        },
+      );
+    }
+
+    const resend = new Resend(apiKey);
+    const {
+      documentType,
+      documentId,
+      recipientEmail,
       recipientName,
       subject,
       message 

--- a/supabase/functions/send-employee-confirmation/index.ts
+++ b/supabase/functions/send-employee-confirmation/index.ts
@@ -2,8 +2,6 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { Resend } from "npm:resend@2.0.0";
 
-const resend = new Resend(Deno.env.get("RESEND_API_KEY"));
-
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
@@ -23,13 +21,27 @@ const handler = async (req: Request): Promise<Response> => {
   }
 
   if (req.method !== "POST") {
-    return new Response("Method not allowed", { 
-      status: 405, 
-      headers: corsHeaders 
+    return new Response("Method not allowed", {
+      status: 405,
+      headers: corsHeaders
     });
   }
 
   try {
+    const apiKey = Deno.env.get("RESEND_API_KEY");
+    if (!apiKey) {
+      const message = "Missing RESEND_API_KEY configuration";
+      console.error(message);
+      return new Response(
+        JSON.stringify({ success: false, error: message }),
+        {
+          status: 500,
+          headers: { "Content-Type": "application/json", ...corsHeaders },
+        },
+      );
+    }
+
+    const resend = new Resend(apiKey);
     const { managerEmail, employeeName, employeeEmail, companyName }: EmployeeConfirmationRequest = await req.json();
 
     console.log("Sending employee confirmation email to:", managerEmail);


### PR DESCRIPTION
## Summary
- verify `RESEND_API_KEY` is set before using Resend
- return an explicit 500 error if the key is missing

## Testing
- `npm run lint` *(fails: Unexpected any and other style errors)*
- `npx eslint supabase/functions/send-employee-confirmation/index.ts supabase/functions/send-document-email/index.ts` *(fails: prefer-const, no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_e_687f90d7abbc832c8660cb4f89108835