### PR TITLE
Add dynamic KPIs on dashboard

### DIFF
--- a/src/components/DashboardStatsWithKpis.tsx
+++ b/src/components/DashboardStatsWithKpis.tsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Building2, Users, DollarSign, CheckSquare } from 'lucide-react';
+import { supabase } from '@/integrations/supabase/client';
+
+/**
+ * DashboardStatsWithKpis fetches real data from Supabase and displays
+ * the most important KPIs for the company on the dashboard. It replaces
+ * the static dashboard cards with dynamic values like number of open
+ * projects, active employees and open invoices. An optional callback
+ * can be provided to navigate to a module when a card is clicked.
+ */
+interface DashboardCard {
+  title: string;
+  description: string;
+  icon: any;
+  buttonText: string;
+  onClick?: () => void;
+}
+
+const DashboardStatsWithKpis: React.FC<{ onNavigate?: (moduleId: string) => void }> = ({ onNavigate }) => {
+  const [openProjects, setOpenProjects] = useState(0);
+  const [activeEmployees, setActiveEmployees] = useState(0);
+  const [openInvoices, setOpenInvoices] = useState(0);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const loadKpis = async () => {
+      // Open projects: status not 'abgeschlossen'
+      const { data: projectData, error: projectError } = await supabase
+        .from('projects')
+        .select('status');
+      if (!projectError && projectData) {
+        setOpenProjects(projectData.filter((p) => p.status !== 'abgeschlossen').length);
+      }
+      // Active employees
+      const { data: employeeData, error: employeeError } = await supabase
+        .from('employees')
+        .select('id')
+        .eq('status', 'aktiv');
+      if (!employeeError && employeeData) {
+        setActiveEmployees(employeeData.length);
+      }
+      // Open invoices (status == 'offen')
+      const { data: invoiceData, error: invoiceError } = await supabase
+        .from('invoices')
+        .select('id')
+        .eq('status', 'offen');
+      if (!invoiceError && invoiceData) {
+        setOpenInvoices(invoiceData.length);
+      }
+      setLoading(false);
+    };
+    loadKpis();
+  }, []);
+
+  const cards: DashboardCard[] = [
+    {
+      title: 'Aktive Projekte',
+      description: loading ? '…' : `${openProjects} laufende Projekte`,
+      icon: Building2,
+      buttonText: 'Projekte',
+      onClick: () => onNavigate?.('projects'),
+    },
+    {
+      title: 'Auslastung',
+      description: loading ? '…' : `${activeEmployees} aktive Mitarbeiter`,
+      icon: Users,
+      buttonText: 'Mitarbeiter',
+      onClick: () => onNavigate?.('employees'),
+    },
+    {
+      title: 'Offene Rechnungen',
+      description: loading ? '…' : `${openInvoices} offen`,
+      icon: DollarSign,
+      buttonText: 'Buchhaltung',
+      onClick: () => onNavigate?.('finance'),
+    },
+    {
+      title: 'Neue Aufgabe',
+      description: 'Leg eine Aufgabe oder einen Zeitstempel an',
+      icon: CheckSquare,
+      buttonText: 'Aufgabe',
+      onClick: () => onNavigate?.('tasks'),
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+      {cards.map((card) => (
+        <Card
+          key={card.title}
+          className="flex flex-col justify-between cursor-pointer"
+          onClick={card.onClick}
+        >
+          <CardHeader className="flex flex-row items-center gap-3">
+            <card.icon className="w-6 h-6 text-blue-500" />
+            <CardTitle>{card.title}</CardTitle>
+          </CardHeader>
+            <CardContent>
+              <p className="text-sm text-gray-600 mb-4">{card.description}</p>
+              <Button variant="outline" className="w-full">
+                {card.buttonText}
+              </Button>
+            </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+};
+
+export default DashboardStatsWithKpis;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -19,7 +19,7 @@ import { DocumentModule } from "@/components/DocumentModule";
 import { CompanySettingsModule } from "@/components/CompanySettingsModule";
 import { EmailModule } from "@/components/EmailModule";
 import DashboardCalendar from "@/components/DashboardCalendar";
-import DashboardStats from "@/components/DashboardStats";
+import DashboardStatsWithKpis from "@/components/DashboardStatsWithKpis";
 import { toast } from "@/hooks/use-toast";
 const Index = () => {
   const {
@@ -77,7 +77,7 @@ const Index = () => {
       case 'company-settings':
         return <CompanySettingsModule />;
       default:
-        return <DashboardStats />;
+        return <DashboardStatsWithKpis onNavigate={setActiveModule} />;
     }
   };
   return <div className="min-h-screen w-full bg-background">


### PR DESCRIPTION
## Summary
- fetch open projects, active employees and open invoices
- display these KPIs on the dashboard
- use new component from the index page

## Testing
- `npm run lint` *(fails: Unexpected any errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688627192e38832ca578acad733f31fc