### PR TITLE
Add reorder suggestions component

### DIFF
--- a/src/components/MaterialModule.tsx
+++ b/src/components/MaterialModule.tsx
@@ -6,6 +6,7 @@ import { Progress } from "@/components/ui/progress";
 import { Input } from "@/components/ui/input";
 import { Package, AlertTriangle, TrendingDown, TrendingUp, Plus, Search, Truck, Edit } from "lucide-react";
 import EditMaterialDialog from "./EditMaterialDialog";
+import ReorderSuggestions from "./material/ReorderSuggestions";
 
 const MaterialModule = () => {
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
@@ -358,8 +359,10 @@ const MaterialModule = () => {
                   <span className="text-xs text-yellow-600">25 Stk</span>
                 </div>
               </div>
-            </CardContent>
+          </CardContent>
           </Card>
+
+          <ReorderSuggestions materials={materials} />
         </div>
       </div>
 

--- a/src/components/material/ReorderSuggestions.tsx
+++ b/src/components/material/ReorderSuggestions.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+
+export interface MaterialItem {
+  id: string;
+  name: string;
+  currentStock: number;
+  minStock: number;
+  maxStock: number;
+  unit: string;
+}
+
+interface ReorderSuggestionsProps {
+  materials: MaterialItem[];
+}
+
+const ReorderSuggestions = ({ materials }: ReorderSuggestionsProps) => {
+  const lowStockItems = materials.filter((m) => m.currentStock <= m.minStock);
+
+  if (lowStockItems.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Bestellvorschl\xC3\xA4ge</CardTitle>
+      </CardHeader>
+      <CardContent className="p-4">
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr>
+              <th className="border-b pb-1 text-left">Material</th>
+              <th className="border-b pb-1 text-right">akt. Bestand</th>
+              <th className="border-b pb-1 text-right">Mindestbestand</th>
+              <th className="border-b pb-1 text-right">Vorschlag</th>
+            </tr>
+          </thead>
+          <tbody>
+            {lowStockItems.map((item) => {
+              const reorderQty = item.maxStock - item.currentStock;
+              return (
+                <tr key={item.id} className="border-b last:border-b-0">
+                  <td className="py-1 pr-2">{item.name}</td>
+                  <td className="py-1 pr-2 text-right">
+                    {item.currentStock} {item.unit}
+                  </td>
+                  <td className="py-1 pr-2 text-right">
+                    {item.minStock} {item.unit}
+                  </td>
+                  <td className="py-1 text-right font-medium">
+                    {reorderQty} {item.unit}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default ReorderSuggestions;


### PR DESCRIPTION
## Summary
- add a reusable `ReorderSuggestions` component
- show reorder suggestions in `MaterialModule`

## Testing
- `npm run build`
- `npm run lint` *(fails: 54 errors, 24 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688636618b30832c82d27e21dc4f4309