### PR TITLE
Add signature capture dialog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "react-hook-form": "^7.53.0",
         "react-resizable-panels": "^2.1.3",
         "react-router-dom": "^6.26.2",
+        "react-signature-canvas": "^1.0.7",
         "recharts": "^2.12.7",
         "resend": "^4.7.0",
         "sonner": "^1.5.0",
@@ -7399,6 +7400,21 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/react-signature-canvas": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/react-signature-canvas/-/react-signature-canvas-1.0.7.tgz",
+      "integrity": "sha512-yo0x0uTMVmcClaqryuQu6F8xEVapk5zdM9/nuQ7GalDJWccoVNZPMmCFGK7U5r3I0mrEHPB9E5/rFSYUgZcfmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "signature_pad": "^2.3.2",
+        "trim-canvas": "^0.1.0"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.5.8",
+        "react": "0.14 - 19",
+        "react-dom": "0.14 - 19"
+      }
+    },
     "node_modules/react-smooth": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.1.tgz",
@@ -7847,6 +7863,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/signature_pad": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/signature_pad/-/signature_pad-2.3.2.tgz",
+      "integrity": "sha512-peYXLxOsIY6MES2TrRLDiNg2T++8gGbpP2yaC+6Ohtxr+a2dzoaqWosWDY9sWqTAAk6E/TyQO+LJw9zQwyu5kA==",
+      "license": "MIT"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -8235,6 +8257,12 @@
       "bin": {
         "tree-kill": "cli.js"
       }
+    },
+    "node_modules/trim-canvas": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/trim-canvas/-/trim-canvas-0.1.2.tgz",
+      "integrity": "sha512-nd4Ga3iLFV94mdhW9JFMLpQbHUyCQuhFOD71PEAt1NjtMD5wbZctzhX8c3agHNybMR5zXD1XTGoIEWk995E6pQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/ts-api-utils": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "react-hook-form": "^7.53.0",
     "react-resizable-panels": "^2.1.3",
     "react-router-dom": "^6.26.2",
+    "react-signature-canvas": "^1.0.7",
     "recharts": "^2.12.7",
     "resend": "^4.7.0",
     "sonner": "^1.5.0",

--- a/src/components/DocumentModule.tsx
+++ b/src/components/DocumentModule.tsx
@@ -21,6 +21,7 @@ import { useToast } from '@/hooks/use-toast';
 import { AddQuoteDialog } from './AddQuoteDialog';
 import { AddInvoiceDialog } from './AddInvoiceDialog';
 import QuoteActions from './QuoteActions';
+import DocumentSignatureDialog from './DocumentSignatureDialog';
 
 interface Quote {
   id: string;
@@ -286,6 +287,13 @@ export function DocumentModule() {
                           <Button variant="ghost" size="sm" title="Herunterladen">
                             <Download className="h-4 w-4" />
                           </Button>
+                          <DocumentSignatureDialog
+                            documentType="quote"
+                            documentId={quote.id}
+                            onSigned={() =>
+                              queryClient.invalidateQueries({ queryKey: ['quotes'] })
+                            }
+                          />
                           <QuoteActions
                             quote={quote}
                             onRefresh={() =>
@@ -364,6 +372,13 @@ export function DocumentModule() {
                           <Button variant="ghost" size="sm" title="Herunterladen">
                             <Download className="h-4 w-4" />
                           </Button>
+                          <DocumentSignatureDialog
+                            documentType="invoice"
+                            documentId={invoice.id}
+                            onSigned={() =>
+                              queryClient.invalidateQueries({ queryKey: ['invoices'] })
+                            }
+                          />
                         </div>
                       </div>
                     </div>

--- a/src/components/DocumentSignatureDialog.tsx
+++ b/src/components/DocumentSignatureDialog.tsx
@@ -1,0 +1,130 @@
+import React, { useRef, useState } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, DialogFooter } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { supabase } from "@/integrations/supabase/client";
+import SignatureCanvas from "react-signature-canvas";
+import { toast } from "@/components/ui/use-toast";
+
+interface DocumentSignatureDialogProps {
+  documentType: "quote" | "invoice";
+  documentId: string;
+  onSigned?: () => void;
+}
+
+const DocumentSignatureDialog: React.FC<DocumentSignatureDialogProps> = ({
+  documentType,
+  documentId,
+  onSigned,
+}) => {
+  const [open, setOpen] = useState(false);
+  const sigPadRef = useRef<SignatureCanvas | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleClear = () => {
+    sigPadRef.current?.clear();
+  };
+
+  const handleSave = async () => {
+    if (isSaving) return;
+    const signaturePad = sigPadRef.current;
+    if (!signaturePad || signaturePad.isEmpty()) {
+      toast({
+        title: "Keine Unterschrift gefunden",
+        description: "Bitte zeichnen Sie zuerst Ihre Unterschrift.",
+        variant: "destructive",
+      });
+      return;
+    }
+    setIsSaving(true);
+    try {
+      const dataUrl = signaturePad.getTrimmedCanvas().toDataURL("image/png");
+      const res = await fetch(dataUrl);
+      const blob = await res.blob();
+
+      const filePath = `${documentType}-signatures/${documentId}-${Date.now()}.png`;
+
+      const { error: uploadError, data: uploadData } = await supabase.storage
+        .from("document-signatures")
+        .upload(filePath, blob, {
+          cacheControl: "3600",
+          upsert: false,
+          contentType: "image/png",
+        });
+      if (uploadError) {
+        throw uploadError;
+      }
+
+      const {
+        data: { publicUrl },
+      } = supabase.storage
+        .from("document-signatures")
+        .getPublicUrl(uploadData.path);
+
+      const table = documentType === "quote" ? "quotes" : "invoices";
+      const { error: updateError } = await supabase
+        .from(table)
+        .update({ signature_url: publicUrl })
+        .eq("id", documentId);
+      if (updateError) {
+        throw updateError;
+      }
+
+      toast({
+        title: "Unterschrift gespeichert",
+        description: "Die Unterschrift wurde erfolgreich hochgeladen.",
+      });
+      handleClear();
+      setOpen(false);
+      onSigned?.();
+    } catch (error) {
+      console.error("Error saving signature:", error);
+      toast({
+        title: "Fehler",
+        description: "Beim Speichern der Unterschrift ist ein Fehler aufgetreten.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline">Unterschrift erfassen</Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>
+            Unterschrift für {documentType === "quote" ? "Angebot" : "Rechnung"}
+          </DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col space-y-4">
+          <div className="border rounded-md p-2 bg-gray-50">
+            <SignatureCanvas
+              ref={sigPadRef}
+              penColor="#000000"
+              canvasProps={{
+                width: 600,
+                height: 200,
+                className: "signature-canvas bg-white",
+              }}
+            />
+          </div>
+          <div className="flex justify-between space-x-2">
+            <Button variant="secondary" onClick={handleClear} disabled={isSaving}>
+              Zurücksetzen
+            </Button>
+            <Button onClick={handleSave} disabled={isSaving}>
+              {isSaving ? "Speichern…" : "Speichern"}
+            </Button>
+          </div>
+        </div>
+        <DialogFooter></DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default DocumentSignatureDialog;
+

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -690,6 +690,7 @@ export type Database = {
           currency: string | null
           customer_id: string
           description: string | null
+          signature_url: string | null
           due_date: string
           id: string
           invoice_date: string
@@ -711,6 +712,7 @@ export type Database = {
           currency?: string | null
           customer_id: string
           description?: string | null
+          signature_url?: string | null
           due_date: string
           id?: string
           invoice_date?: string
@@ -732,6 +734,7 @@ export type Database = {
           currency?: string | null
           customer_id?: string
           description?: string | null
+          signature_url?: string | null
           due_date?: string
           id?: string
           invoice_date?: string
@@ -1189,6 +1192,7 @@ export type Database = {
           currency: string | null
           customer_id: string
           description: string | null
+          signature_url: string | null
           id: string
           net_amount: number
           notes: string | null
@@ -1208,6 +1212,7 @@ export type Database = {
           currency?: string | null
           customer_id: string
           description?: string | null
+          signature_url?: string | null
           id?: string
           net_amount?: number
           notes?: string | null
@@ -1227,6 +1232,7 @@ export type Database = {
           currency?: string | null
           customer_id?: string
           description?: string | null
+          signature_url?: string | null
           id?: string
           net_amount?: number
           notes?: string | null


### PR DESCRIPTION
## Summary
- add `react-signature-canvas` dependency
- implement `DocumentSignatureDialog` component
- allow signing quotes and invoices in `DocumentModule`
- extend Supabase types with `signature_url`

## Testing
- `npm run lint` *(fails: 55 errors, 28 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68864a3ac240832caa5e816782ca78c8