### PR TITLE
Add document signature dialog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "react-hook-form": "^7.53.0",
         "react-resizable-panels": "^2.1.3",
         "react-router-dom": "^6.26.2",
+        "react-signature-canvas": "^1.0.7",
         "recharts": "^2.12.7",
         "resend": "^4.7.0",
         "sonner": "^1.5.0",
@@ -7399,6 +7400,21 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/react-signature-canvas": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/react-signature-canvas/-/react-signature-canvas-1.0.7.tgz",
+      "integrity": "sha512-yo0x0uTMVmcClaqryuQu6F8xEVapk5zdM9/nuQ7GalDJWccoVNZPMmCFGK7U5r3I0mrEHPB9E5/rFSYUgZcfmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "signature_pad": "^2.3.2",
+        "trim-canvas": "^0.1.0"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.5.8",
+        "react": "0.14 - 19",
+        "react-dom": "0.14 - 19"
+      }
+    },
     "node_modules/react-smooth": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.1.tgz",
@@ -7847,6 +7863,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/signature_pad": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/signature_pad/-/signature_pad-2.3.2.tgz",
+      "integrity": "sha512-peYXLxOsIY6MES2TrRLDiNg2T++8gGbpP2yaC+6Ohtxr+a2dzoaqWosWDY9sWqTAAk6E/TyQO+LJw9zQwyu5kA==",
+      "license": "MIT"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -8235,6 +8257,12 @@
       "bin": {
         "tree-kill": "cli.js"
       }
+    },
+    "node_modules/trim-canvas": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/trim-canvas/-/trim-canvas-0.1.2.tgz",
+      "integrity": "sha512-nd4Ga3iLFV94mdhW9JFMLpQbHUyCQuhFOD71PEAt1NjtMD5wbZctzhX8c3agHNybMR5zXD1XTGoIEWk995E6pQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/ts-api-utils": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "react-hook-form": "^7.53.0",
     "react-resizable-panels": "^2.1.3",
     "react-router-dom": "^6.26.2",
+    "react-signature-canvas": "^1.0.7",
     "recharts": "^2.12.7",
     "resend": "^4.7.0",
     "sonner": "^1.5.0",

--- a/src/components/DocumentSignatureDialog.tsx
+++ b/src/components/DocumentSignatureDialog.tsx
@@ -1,0 +1,157 @@
+import React, { useRef, useState } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, DialogFooter } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { supabase } from "@/integrations/supabase/client";
+import SignatureCanvas from "react-signature-canvas";
+import { toast } from "@/components/ui/use-toast";
+
+/**
+ * DocumentSignatureDialog allows a user to capture a signature for a quote or invoice.
+ *
+ * Props:
+ *  - documentType: Type of the document (e.g. "quote" or "invoice").
+ *  - documentId: UUID of the document that should be signed.
+ *  - onSigned: Callback fired after signature is saved (optional).
+ *
+ * The component uses react-signature-canvas to capture the signature. When the
+ * user clicks "Speichern", the drawn signature is trimmed and uploaded to
+ * Supabase Storage under the bucket "document-signatures". The stored path
+ * includes the document type and ID for easier association. After upload, the
+ * corresponding row in the documents table is updated with a `signature_url`.
+ */
+interface DocumentSignatureDialogProps {
+  documentType: "quote" | "invoice";
+  documentId: string;
+  onSigned?: () => void;
+}
+
+const DocumentSignatureDialog: React.FC<DocumentSignatureDialogProps> = ({
+  documentType,
+  documentId,
+  onSigned,
+}) => {
+  const [open, setOpen] = useState(false);
+  const sigPadRef = useRef<SignatureCanvas | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  /**
+   * Clears the current signature drawing from the canvas.
+   */
+  const handleClear = () => {
+    sigPadRef.current?.clear();
+  };
+
+  /**
+   * Handles saving of the signature: uploads the image and updates the document.
+   */
+  const handleSave = async () => {
+    if (isSaving) return;
+    const signaturePad = sigPadRef.current;
+    if (!signaturePad || signaturePad.isEmpty()) {
+      toast({
+        title: "Keine Unterschrift gefunden",
+        description: "Bitte zeichnen Sie zuerst Ihre Unterschrift.",
+        variant: "destructive",
+      });
+      return;
+    }
+    setIsSaving(true);
+    try {
+      // Generate data URL and convert to Blob
+      const dataUrl = signaturePad.getTrimmedCanvas().toDataURL("image/png");
+      const res = await fetch(dataUrl);
+      const blob = await res.blob();
+
+      // Define file path: use document type and ID with timestamp to avoid collisions
+      const filePath = `${documentType}-signatures/${documentId}-${Date.now()}.png`;
+
+      // Upload the signature to Supabase Storage
+      const { error: uploadError, data: uploadData } = await supabase.storage
+        .from("document-signatures")
+        .upload(filePath, blob, {
+          cacheControl: "3600",
+          upsert: false,
+          contentType: "image/png",
+        });
+      if (uploadError) {
+        throw uploadError;
+      }
+
+      // Construct public URL for the uploaded file
+      const {
+        data: { publicUrl },
+      } = supabase.storage
+        .from("document-signatures")
+        .getPublicUrl(uploadData.path);
+
+      // Determine which table to update and update the signature URL field
+      const table = documentType === "quote" ? "quotes" : "invoices";
+      const { error: updateError } = await supabase
+        .from(table)
+        .update({ signature_url: publicUrl })
+        .eq("id", documentId);
+      if (updateError) {
+        throw updateError;
+      }
+
+      toast({
+        title: "Unterschrift gespeichert",
+        description: "Die Unterschrift wurde erfolgreich hochgeladen.",
+      });
+      // Close the dialog and reset
+      handleClear();
+      setOpen(false);
+      onSigned?.();
+    } catch (error) {
+      console.error("Error saving signature:", error);
+      toast({
+        title: "Fehler",
+        description: "Beim Speichern der Unterschrift ist ein Fehler aufgetreten.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline">Unterschrift erfassen</Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>
+            Unterschrift für {documentType === "quote" ? "Angebot" : "Rechnung"}
+          </DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col space-y-4">
+          <div className="border rounded-md p-2 bg-gray-50">
+            <SignatureCanvas
+              ref={sigPadRef}
+              penColor="#000000"
+              canvasProps={{
+                width: 600,
+                height: 200,
+                className: "signature-canvas bg-white",
+              }}
+            />
+          </div>
+          <div className="flex justify-between space-x-2">
+            <Button variant="secondary" onClick={handleClear} disabled={isSaving}>
+              Zurücksetzen
+            </Button>
+            <Button onClick={handleSave} disabled={isSaving}>
+              {isSaving ? "Speichern…" : "Speichern"}
+            </Button>
+          </div>
+        </div>
+        <DialogFooter>
+          {/* Optional additional instructions or status messages can be inserted here */}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default DocumentSignatureDialog;


### PR DESCRIPTION
## Summary
- add a `DocumentSignatureDialog` React component to capture signatures
- install and configure `react-signature-canvas`

## Testing
- `npm install`
- `npm run lint` *(fails: prefer-const and no-explicit-any errors in unrelated files)*
- `npx eslint src/components/DocumentSignatureDialog.tsx`

------
https://chatgpt.com/codex/tasks/task_e_688662f3e008832c87e80d091067d851