### PR TITLE
Update email sender domain

### DIFF
--- a/scripts/inviteEmployee.ts
+++ b/scripts/inviteEmployee.ts
@@ -34,7 +34,7 @@ async function generateInviteLink(email: string) {
 
 async function sendInvite(email: string, link: string) {
   const { data, error } = await resend.emails.send({
-    from: 'Acme <noreply@example.com>',
+    from: 'HandwerkOS <onboarding@no-replyhandwerkos.de>',
     to: [email],
     subject: 'Setze dein Passwort',
     html: `<p>Klicke <a href="${link}">hier</a>, um dein Passwort zu setzen.</p>`

--- a/supabase/functions/send-document-email/index.ts
+++ b/supabase/functions/send-document-email/index.ts
@@ -189,7 +189,7 @@ const handler = async (req: Request): Promise<Response> => {
     `;
 
     const emailResponse = await resend.emails.send({
-      from: "HandwerkOS <noreply@resend.dev>",
+      from: "HandwerkOS <noreply@no-replyhandwerkos.de>",
       to: [recipientEmail],
       subject: emailSubject,
       html: emailHtml,

--- a/supabase/functions/send-employee-confirmation/index.ts
+++ b/supabase/functions/send-employee-confirmation/index.ts
@@ -75,7 +75,7 @@ const handler = async (req: Request): Promise<Response> => {
 
     // Send email to manager
     const managerEmailResponse = await resend.emails.send({
-      from: "HandwerkOS <onboarding@resend.dev>",
+      from: "HandwerkOS <onboarding@no-replyhandwerkos.de>",
       to: [sanitizedManagerEmail],
       subject: `Neuer Mitarbeiter erfolgreich registriert - ${sanitizedEmployeeName}`,
       html: `
@@ -122,7 +122,7 @@ const handler = async (req: Request): Promise<Response> => {
     const finalRegistrationUrl = registrationUrl || `https://lovable.dev/auth?mode=employee-setup`;
     
     const employeeEmailResponse = await resend.emails.send({
-      from: "HandwerkOS <onboarding@resend.dev>",
+      from: "HandwerkOS <onboarding@no-replyhandwerkos.de>",
       to: [sanitizedEmployeeEmail],
       subject: `Willkommen bei HandwerkOS - Registrierung abschließen`,
       html: `


### PR DESCRIPTION
## Summary
- use `onboarding@no-replyhandwerkos.de` when sending employee confirmation emails
- update document email sender to `noreply@no-replyhandwerkos.de`
- update inviteEmployee script sender

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68877c6f8448832cb0465e62c5427b6b