### PR TITLE
Fix employee setup link

### DIFF
--- a/scripts/inviteEmployee.ts
+++ b/scripts/inviteEmployee.ts
@@ -19,10 +19,14 @@ const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 const resend = new Resend(RESEND_API_KEY);
 
 async function generateInviteLink(email: string) {
+  const defaultRedirect =
+    process.env.EMPLOYEE_REGISTRATION_URL ||
+    'https://handwerkos.com/auth?mode=employee-setup';
+
   const { data, error } = await supabase.auth.admin.generateLink({
     type: 'invite',
     email,
-    options: { redirectTo: 'https://lovable.dev/auth?mode=employee-setup' }
+    options: { redirectTo: defaultRedirect }
   });
 
   if (error) {

--- a/supabase/functions/send-employee-confirmation/index.ts
+++ b/supabase/functions/send-employee-confirmation/index.ts
@@ -119,7 +119,10 @@ const handler = async (req: Request): Promise<Response> => {
     });
 
     // Send registration email to employee
-    const finalRegistrationUrl = registrationUrl || `https://lovable.dev/auth?mode=employee-setup`;
+    const defaultRegistrationUrl =
+      Deno.env.get("EMPLOYEE_REGISTRATION_URL") ||
+      "https://handwerkos.com/auth?mode=employee-setup";
+    const finalRegistrationUrl = registrationUrl || defaultRegistrationUrl;
     
     const employeeEmailResponse = await resend.emails.send({
       from: "HandwerkOS <onboarding@no-replyhandwerkos.de>",


### PR DESCRIPTION
## Summary
- default employee invitation URL to our HandwerkOS domain
- read custom employee registration URL from environment variables

## Testing
- `npm run lint` *(fails: prefer-const, no-explicit-any, no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_6887a839eb8c832c9e8fce42f01b12d0