### PR TITLE
Add phone to employee invite

### DIFF
--- a/src/components/PersonalModule.tsx
+++ b/src/components/PersonalModule.tsx
@@ -64,7 +64,8 @@ const PersonalModule = () => {
           id,
           email,
           first_name,
-          last_name
+          last_name,
+          phone
         `);
 
       if (profilesError) {
@@ -101,7 +102,7 @@ const PersonalModule = () => {
         name: `${profile.first_name || ''} ${profile.last_name || ''}`.trim() || profile.email,
         position: 'Mitarbeiter', // Default position, could be stored in profiles later
         email: profile.email,
-        phone: '', // Could be added to profiles table later
+        phone: profile.phone || '',
         status: 'Aktiv',
         qualifications: [],
         license: '',
@@ -144,6 +145,7 @@ const PersonalModule = () => {
           email: newEmployee.email,
           first_name: newEmployee.firstName,
           last_name: newEmployee.lastName,
+          phone: newEmployee.phone,
           company_id: profile.company_id
         }
       });

--- a/supabase/functions/invite-employee/index.ts
+++ b/supabase/functions/invite-employee/index.ts
@@ -19,7 +19,7 @@ const handler = async (req: Request): Promise<Response> => {
   }
 
   try {
-    const { email, first_name, last_name, company_id } = await req.json();
+    const { email, first_name, last_name, company_id, phone } = await req.json();
 
     // Input validation and sanitization
     if (!email || !company_id) {
@@ -42,6 +42,7 @@ const handler = async (req: Request): Promise<Response> => {
     const sanitizedEmail = email.trim().toLowerCase();
     const sanitizedFirstName = first_name?.trim().substring(0, 100) || '';
     const sanitizedLastName = last_name?.trim().substring(0, 100) || '';
+    const sanitizedPhone = phone ? phone.trim().replace(/[^0-9+]/g, '') : '';
 
     const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
     const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
@@ -51,10 +52,11 @@ const handler = async (req: Request): Promise<Response> => {
     const { data, error } = await supabase.auth.admin.createUser({
       email: sanitizedEmail,
       email_confirm: false,
-      user_metadata: { 
-        company_id, 
-        first_name: sanitizedFirstName, 
-        last_name: sanitizedLastName 
+      user_metadata: {
+        company_id,
+        first_name: sanitizedFirstName,
+        last_name: sanitizedLastName,
+        phone: sanitizedPhone
       }
     });
 


### PR DESCRIPTION
## Summary
- include phone column when fetching employees
- pass phone when invoking `invite-employee`
- allow phone metadata in the `invite-employee` function

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6887b791ebd0832c89f84b3a1d0c5bba