### PR TITLE
Fix lint issues in PersonalModule and invite-employee

### DIFF
--- a/src/components/PersonalModule.tsx
+++ b/src/components/PersonalModule.tsx
@@ -197,7 +197,7 @@ const PersonalModule = () => {
     setIsEditOpen(true);
   };
 
-  const handleSaveEmployee = (editFormData: any) => {
+  const handleSaveEmployee = (editFormData: Partial<Employee>) => {
     if (!selectedEmployee) return;
 
     const updatedEmployee = {

--- a/supabase/functions/invite-employee/index.ts
+++ b/supabase/functions/invite-employee/index.ts
@@ -75,10 +75,11 @@ const handler = async (req: Request): Promise<Response> => {
       }),
       { status: 200, headers: { "Content-Type": "application/json", ...corsHeaders } }
     );
-  } catch (err: any) {
+  } catch (err: unknown) {
     console.error("invite-employee error", err);
+    const message = err instanceof Error ? err.message : String(err);
     return new Response(
-      JSON.stringify({ error: err.message }),
+      JSON.stringify({ error: message }),
       { status: 500, headers: { "Content-Type": "application/json", ...corsHeaders } }
     );
   }


### PR DESCRIPTION
## Summary
- improve handleSaveEmployee typing in `PersonalModule`
- refine error handling in `invite-employee` function

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6887c8537d60832ca0aa958a561220c7