### PR TITLE
Ensure invite link flow is consistent

### DIFF
--- a/src/components/PersonalModule.tsx
+++ b/src/components/PersonalModule.tsx
@@ -154,6 +154,11 @@ const PersonalModule = () => {
         return;
       }
 
+      if (!inviteData?.invite_link) {
+        toast.error('Kein Einladungslink erhalten');
+        return;
+      }
+
       console.log('Inviting employee via edge function:', newEmployee.email);
 
       try {
@@ -197,7 +202,7 @@ const PersonalModule = () => {
     setIsEditOpen(true);
   };
 
-  const handleSaveEmployee = (editFormData: any) => {
+  const handleSaveEmployee = (editFormData: Record<string, unknown>) => {
     if (!selectedEmployee) return;
 
     const updatedEmployee = {

--- a/supabase/functions/invite-employee/index.ts
+++ b/supabase/functions/invite-employee/index.ts
@@ -68,17 +68,25 @@ const handler = async (req: Request): Promise<Response> => {
       );
     }
 
+    if (!data?.action_link) {
+      return new Response(
+        JSON.stringify({ error: "invite link not returned" }),
+        { status: 500, headers: { "Content-Type": "application/json", ...corsHeaders } }
+      );
+    }
+
     return new Response(
-      JSON.stringify({ 
+      JSON.stringify({
         user: data?.user,
-        invite_link: data?.action_link 
+        invite_link: data?.action_link
       }),
       { status: 200, headers: { "Content-Type": "application/json", ...corsHeaders } }
     );
-  } catch (err: any) {
+  } catch (err: unknown) {
     console.error("invite-employee error", err);
+    const message = err instanceof Error ? err.message : String(err);
     return new Response(
-      JSON.stringify({ error: err.message }),
+      JSON.stringify({ error: message }),
       { status: 500, headers: { "Content-Type": "application/json", ...corsHeaders } }
     );
   }

--- a/supabase/functions/send-employee-confirmation/index.ts
+++ b/supabase/functions/send-employee-confirmation/index.ts
@@ -202,18 +202,19 @@ const handler = async (req: Request): Promise<Response> => {
         ...corsHeaders,
       },
     });
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error("Error in send-employee-confirmation function:", error);
+    const message = error instanceof Error ? error.message : String(error);
     return new Response(
-      JSON.stringify({ 
-        error: error.message,
-        success: false 
+      JSON.stringify({
+        error: message,
+        success: false
       }),
       {
         status: 500,
-        headers: { 
-          "Content-Type": "application/json", 
-          ...corsHeaders 
+        headers: {
+          "Content-Type": "application/json",
+          ...corsHeaders
         },
       }
     );


### PR DESCRIPTION
## Summary
- validate invite link generation in the `invite-employee` edge function
- tighten error handling in both edge functions
- check invite link before sending confirmation email
- remove `any` usages in personal module and functions

## Testing
- `npm install`
- `npx eslint supabase/functions/invite-employee/index.ts supabase/functions/send-employee-confirmation/index.ts src/components/PersonalModule.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6887c853bc20832ca17bf24982164250