### PR TITLE
Fix session initialization for signup

### DIFF
--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -10,6 +10,7 @@ import { Settings, User, UserPlus, Key } from "lucide-react";
 import { useAuth } from "@/hooks/useAuth";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
+import { supabase } from "@/integrations/supabase/client";
 
 const Auth = () => {
   const [isLogin, setIsLogin] = useState(true);
@@ -52,20 +53,30 @@ const Auth = () => {
 
   useEffect(() => {
     // Check if user arrived via email confirmation link
-    const accessToken = searchParams.get('access_token');
-    const refreshToken = searchParams.get('refresh_token');
-    const type = searchParams.get('type');
-    const mode = searchParams.get('mode');
-    
-    if (accessToken && refreshToken && type === 'signup') {
-      setIsPasswordSetup(true);
-      setIsLogin(false);
-    }
-    
-    // Hide login/register toggle for employee setup
-    if (mode === 'employee-setup') {
-      setIsPasswordSetup(true);
-    }
+    const hashParams = new URLSearchParams(window.location.hash.slice(1));
+    const accessToken = searchParams.get('access_token') || hashParams.get('access_token');
+    const refreshToken = searchParams.get('refresh_token') || hashParams.get('refresh_token');
+    const type = searchParams.get('type') || hashParams.get('type');
+    const mode = searchParams.get('mode') || hashParams.get('mode');
+
+    const initSession = async () => {
+      // Initialize session so password setup can update user without errors
+      if (accessToken && refreshToken && type === 'signup') {
+        await supabase.auth.setSession({
+          access_token: accessToken,
+          refresh_token: refreshToken
+        });
+        setIsPasswordSetup(true);
+        setIsLogin(false);
+      }
+
+      // Hide login/register toggle for employee setup
+      if (mode === 'employee-setup') {
+        setIsPasswordSetup(true);
+      }
+    };
+
+    initSession();
   }, [searchParams]);
 
   const handleSubmit = async (e: React.FormEvent) => {

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -52,7 +52,7 @@ const Auth = () => {
   }, [user, navigate, searchParams, isPasswordSetup]);
 
   useEffect(() => {
-    // Check if user arrived via email confirmation link
+    // Check if user arrived via signup or confirmation link and set session
     const hashParams = new URLSearchParams(window.location.hash.slice(1));
     const accessToken = searchParams.get('access_token') || hashParams.get('access_token');
     const refreshToken = searchParams.get('refresh_token') || hashParams.get('refresh_token');
@@ -60,7 +60,6 @@ const Auth = () => {
     const mode = searchParams.get('mode') || hashParams.get('mode');
 
     const initSession = async () => {
-      // Initialize session so password setup can update user without errors
       if (accessToken && refreshToken && type === 'signup') {
         await supabase.auth.setSession({
           access_token: accessToken,
@@ -69,12 +68,13 @@ const Auth = () => {
         setIsPasswordSetup(true);
         setIsLogin(false);
       }
-
-      // Hide login/register toggle for employee setup
-      if (mode === 'employee-setup') {
-        setIsPasswordSetup(true);
-      }
     };
+
+    // Hide login/register toggle for employee setup
+    if (mode === 'employee-setup') {
+      setIsPasswordSetup(true);
+    }
+
 
     initSession();
   }, [searchParams]);


### PR DESCRIPTION
## Summary
- parse session tokens from both query string and hash
- set the Supabase session so password setup succeeds

## Testing
- `npm run lint` *(fails: 53 errors, 24 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688911b873b0832c9a334aa8bddee375