### PR TITLE
Handle tokens from URL hash for Supabase auth

### DIFF
--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -53,10 +53,12 @@ const Auth = () => {
 
   useEffect(() => {
     // Check if user arrived via email confirmation link
-    const accessToken = searchParams.get('access_token');
-    const refreshToken = searchParams.get('refresh_token');
-    const type = searchParams.get('type');
-    const mode = searchParams.get('mode');
+    const hashParams = new URLSearchParams(window.location.hash.slice(1));
+
+    const accessToken = searchParams.get('access_token') || hashParams.get('access_token');
+    const refreshToken = searchParams.get('refresh_token') || hashParams.get('refresh_token');
+    const type = searchParams.get('type') || hashParams.get('type');
+    const mode = searchParams.get('mode') || hashParams.get('mode');
 
     const initSession = async () => {
       if (accessToken && refreshToken && type === 'signup') {


### PR DESCRIPTION
## Summary
- parse access_token and refresh_token from the URL hash in `Auth.tsx`

## Testing
- `npm run lint` *(fails: 53 errors, 24 warnings)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a21d4d404832c86fbeee90e5e8cff