### PR TITLE
chore: log raw request body in invite employee

### DIFF
--- a/supabase/functions/invite-employee/index.ts
+++ b/supabase/functions/invite-employee/index.ts
@@ -19,7 +19,11 @@ const handler = async (req: Request): Promise<Response> => {
   }
 
   try {
-    const { email, first_name, last_name, company_id } = await req.json();
+    // Debug: kompletten Raw-Body einmal ausgeben
+    const bodyText = await req.text();
+    console.log('INVITE-PAYLOAD:', bodyText);
+    // Anschließend wie gehabt parsen
+    const { email, first_name, last_name, company_id } = JSON.parse(bodyText);
 
     // Input validation and sanitization
     if (!email || !company_id) {


### PR DESCRIPTION
## Summary
- log raw request body at start of invite-employee handler for debugging

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 53 errors, 25 warnings)


------
https://chatgpt.com/codex/tasks/task_e_688cece02e74832ca732d2f2268d226a