### PR TITLE
feat: list user projects with clerk auth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@capacitor/core": "^7.4.2",
         "@capacitor/geolocation": "^7.1.3",
         "@capacitor/ios": "^7.4.2",
+        "@clerk/clerk-react": "^5.38.1",
         "@hookform/resolvers": "^3.9.0",
         "@radix-ui/react-accordion": "^1.2.0",
         "@radix-ui/react-alert-dialog": "^1.1.1",
@@ -246,6 +247,66 @@
       "resolved": "https://registry.npmjs.org/@capacitor/synapse/-/synapse-1.0.3.tgz",
       "integrity": "sha512-7gGvuQ1NlSCwnjdIMkry+/meyUxHTnsVodRxOTOerLAoAyvtSnCp1rKyLjt9kCz9Lf7Y/wUbCe+AWbAvfxL5bA==",
       "license": "ISC"
+    },
+    "node_modules/@clerk/clerk-react": {
+      "version": "5.38.1",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.38.1.tgz",
+      "integrity": "sha512-IOn/Raet3jwkug8P/gLMe2nsw2wKllWGOGPFOAaaYxbXfIZ8MPngNv2/MMgVRF7cAX1UwrmU1PzrLNtBJ/EHPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^3.17.0",
+        "@clerk/types": "^4.72.0",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-0",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-0"
+      }
+    },
+    "node_modules/@clerk/shared": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.17.0.tgz",
+      "integrity": "sha512-eYbA0xmKG1DluFmdVykXiElgZGTpCruEyXmIBAwokpxypd5nOpDsS1xvEKwYvZieLTZkFz21Z3Y6HdDI5cPxBQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/types": "^4.72.0",
+        "dequal": "2.0.3",
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.5",
+        "std-env": "^3.9.0",
+        "swr": "2.3.4"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-0",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clerk/types": {
+      "version": "4.72.0",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.72.0.tgz",
+      "integrity": "sha512-SEkgiQNeTstC0/mQjHCGBEyX0/ALyWAa5QZBBvVOok204r48MLipfIKsXQhyWE2Hk6FIo5WT6YyqD36jaxUEIw==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "3.1.3"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -4792,6 +4853,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
@@ -5500,6 +5570,12 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/glob/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -5849,6 +5925,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {
@@ -7926,6 +8011,12 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "license": "MIT"
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -8098,6 +8189,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
+      "integrity": "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/tailwind-merge": {
@@ -8446,6 +8550,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@capacitor/core": "^7.4.2",
     "@capacitor/geolocation": "^7.1.3",
     "@capacitor/ios": "^7.4.2",
+    "@clerk/clerk-react": "^5.38.1",
     "@hookform/resolvers": "^3.9.0",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.1",

--- a/src/components/MeineProjekte.tsx
+++ b/src/components/MeineProjekte.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useAuth, SignInButton } from '@clerk/clerk-react'
+import { createClerkSupabaseClient } from '@/integrations/supabase/client'
+
+interface Project {
+  id: string
+  name: string
+  description?: string | null
+}
+
+export const MeineProjekte = () => {
+  const { isLoaded, userId, getToken } = useAuth()
+  const supabase = useMemo(() => createClerkSupabaseClient(getToken), [getToken])
+  const [projects, setProjects] = useState<Project[]>([])
+
+  useEffect(() => {
+    if (!userId) return
+    const load = async () => {
+      const { data, error } = await supabase
+        .from('projects')
+        .select('id, name, description')
+        .eq('profile_id', userId)
+      if (!error && data) {
+        setProjects(data as Project[])
+      }
+    }
+    load()
+  }, [userId, supabase])
+
+  if (!isLoaded) {
+    return <div>Laden...</div>
+  }
+
+  if (!userId) {
+    return <SignInButton />
+  }
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold mb-4">Meine Projekte</h2>
+      <ul className="space-y-2">
+        {projects.map(project => (
+          <li key={project.id} className="border rounded p-2">
+            {project.name}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,12 @@
 import { createRoot } from 'react-dom/client'
+import { ClerkProvider } from '@clerk/clerk-react'
 import App from './App.tsx'
 import './index.css'
 
-createRoot(document.getElementById("root")!).render(<App />);
+const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
+
+createRoot(document.getElementById("root")!).render(
+  <ClerkProvider publishableKey={clerkPubKey} afterSignOutUrl="/">
+    <App />
+  </ClerkProvider>
+)

--- a/supabase/migrations/20250804120000-add-projects-profile-id-policy.sql
+++ b/supabase/migrations/20250804120000-add-projects-profile-id-policy.sql
@@ -1,0 +1,13 @@
+-- Add profile_id column referencing profiles table
+ALTER TABLE public.projects
+  ADD COLUMN profile_id uuid REFERENCES public.profiles(id);
+
+-- Ensure RLS is enabled (no-op if already enabled)
+ALTER TABLE public.projects ENABLE ROW LEVEL SECURITY;
+
+-- Policy to allow users to access only their own projects
+CREATE POLICY "Users can manage their projects"
+ON public.projects
+FOR ALL
+USING (auth.uid() = profile_id)
+WITH CHECK (auth.uid() = profile_id);


### PR DESCRIPTION
## Summary
- integrate Clerk provider and auth-aware Supabase client
- add `MeineProjekte` component listing projects of signed-in user
- restrict project access via new `profile_id` column and RLS policy

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 78 problems (54 errors, 24 warnings))*


------
https://chatgpt.com/codex/tasks/task_e_6890d3f6d67c832c8397d05888bc3577