### PR TITLE
fix: add Clerk publishable key

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,10 +3,8 @@ import { ClerkProvider } from '@clerk/clerk-react'
 import App from './App.tsx'
 import './index.css'
 
-const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY
-
-createRoot(document.getElementById("root")!).render(
-  <ClerkProvider publishableKey={clerkPubKey} afterSignOutUrl="/">
+createRoot(document.getElementById('root')!).render(
+  <ClerkProvider publishableKey="pk_test_Y3JlZGlibGUtY293LTI5LmNsZXJrLmFjY291bnRzLmRldiQ" afterSignOutUrl="/">
     <App />
   </ClerkProvider>
 )


### PR DESCRIPTION
## Summary
- hardcode Clerk publishable key in ClerkProvider to avoid runtime error

## Testing
- `npm run lint` *(fails: prefer-const, no-explicit-any, etc.)*
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Multiple exports with the same name "supabase")*


------
https://chatgpt.com/codex/tasks/task_e_6890e95c8ffc832ca45fc49cffc977d9