### PR TITLE
fix: resolve TypeScript errors

### DIFF
--- a/src/components/MeineProjekte.tsx
+++ b/src/components/MeineProjekte.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useAuth, SignInButton } from '@clerk/clerk-react'
 import { createClerkSupabaseClient } from '@/integrations/supabase/client'
+import type { SupabaseClient } from '@supabase/supabase-js'
 
 interface Project {
   id: string
@@ -10,7 +11,7 @@ interface Project {
 
 export const MeineProjekte = () => {
   const { isLoaded, userId, getToken } = useAuth()
-  const supabase = useMemo(() => createClerkSupabaseClient(getToken), [getToken])
+  const supabase = useMemo(() => createClerkSupabaseClient(getToken), [getToken]) as SupabaseClient
   const [projects, setProjects] = useState<Project[]>([])
 
   useEffect(() => {

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -20,9 +20,9 @@ export const createClerkSupabaseClient = (
 ) =>
   createClient<Database>(SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY, {
     global: {
-      fetch: async (url, options = {}) => {
+      fetch: async (url, options: RequestInit = {}) => {
         const token = await getToken({ template: 'supabase' });
-        const headers = new Headers(options?.headers);
+        const headers = new Headers(options.headers);
         if (token) {
           headers.set('Authorization', `Bearer ${token}`);
         }


### PR DESCRIPTION
## Summary
- fix Supabase client fetch types and headers
- adjust Clerk usage in personal and signup flows
- simplify project listing Supabase typing

## Testing
- `npx tsc -p tsconfig.app.json --noEmit`
- `npm run lint` *(fails: prefer-const, no-explicit-any, @typescript-eslint/no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_68910c10d4b0832cac166ba8f3271936