### PR TITLE
Add Supabase database management scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,12 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "db:init": "npx supabase init",
+    "db:start": "npx supabase start",
+    "db:reset": "npx supabase db reset",
+    "db:push": "npx supabase db push",
+    "db:diff": "npx supabase db diff --schema public --local --name"
   },
   "dependencies": {
     "@capacitor/android": "^7.4.2",


### PR DESCRIPTION
## Summary
- add Supabase database control scripts to package.json

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 200 problems (151 errors, 49 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_689cac37e344832c9bfc66fd7312d929