### PR TITLE
feat: Aufmaß-Erfassung (geplant vs. tatsächlich)

### DIFF
--- a/docs/superpowers/plans/2026-04-03-aufmass.md
+++ b/docs/superpowers/plans/2026-04-03-aufmass.md
@@ -1,0 +1,91 @@
+# Aufmaß-Erfassung - Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add simple measurement recording (Aufmaß) to delivery notes — planned vs. actual quantities with photo proof, usable on mobile and desktop.
+
+**Architecture:** Extend delivery_note_items with 4 new columns. New AufmassTab component in DeliveryNoteForm. Extend MobileMaterialRecorder with Aufmaß toggle. Update invoice creation to use actual quantities.
+
+**Tech Stack:** React 18 + TypeScript, shadcn/ui, Supabase, Capacitor Camera (mobile).
+
+---
+
+## File Structure
+
+### New files:
+```
+src/components/delivery-notes/AufmassTab.tsx    # Aufmaß tab for DeliveryNoteForm
+```
+
+### Files to modify:
+- `src/components/delivery-notes/DeliveryNoteForm.tsx` — Add Aufmaß tab
+- `src/components/mobile/MobileMaterialRecorder.tsx` — Add Aufmaß mode toggle
+- `src/components/CreateInvoiceFromProjectDialog.tsx` — Use actual_quantity
+
+---
+
+## Task 1: Database migration
+
+- [ ] **Step 1: Apply migration via Supabase MCP**
+
+```sql
+ALTER TABLE public.delivery_note_items
+  ADD COLUMN IF NOT EXISTS planned_quantity decimal(15,3),
+  ADD COLUMN IF NOT EXISTS actual_quantity decimal(15,3),
+  ADD COLUMN IF NOT EXISTS measurement_note text,
+  ADD COLUMN IF NOT EXISTS measurement_photo_url text;
+```
+
+- [ ] **Step 2: Verify columns exist**
+
+---
+
+## Task 2: Create AufmassTab component
+
+**Files:**
+- Create: `src/components/delivery-notes/AufmassTab.tsx`
+
+- [ ] **Step 1: Create AufmassTab**
+
+The component shows a table of measurement items with planned vs actual quantities. It can import positions from the project's offer.
+
+- [ ] **Step 2: Verify and commit**
+
+---
+
+## Task 3: Wire AufmassTab into DeliveryNoteForm
+
+**Files:**
+- Modify: `src/components/delivery-notes/DeliveryNoteForm.tsx`
+
+- [ ] **Step 1: Add Aufmaß tab**
+
+Add a new tab "Aufmaß" alongside existing Material/Fotos tabs.
+
+- [ ] **Step 2: Verify and commit**
+
+---
+
+## Task 4: Add Aufmaß mode to MobileMaterialRecorder
+
+**Files:**
+- Modify: `src/components/mobile/MobileMaterialRecorder.tsx`
+
+- [ ] **Step 1: Add toggle and measurement fields**
+
+Add an "Aufmaß" toggle that switches to measurement mode with planned/actual/note fields.
+
+- [ ] **Step 2: Verify and commit**
+
+---
+
+## Task 5: Update invoice creation to use actual quantities
+
+**Files:**
+- Modify: `src/components/CreateInvoiceFromProjectDialog.tsx`
+
+- [ ] **Step 1: Use actual_quantity when available**
+
+When creating invoice from project, check if delivery_note_items have actual_quantity set. If yes, use that instead of offer quantity.
+
+- [ ] **Step 2: Verify and commit**

--- a/docs/superpowers/specs/2026-04-03-aufmass-design.md
+++ b/docs/superpowers/specs/2026-04-03-aufmass-design.md
@@ -1,0 +1,93 @@
+# Aufmaß-Erfassung - Design Spec
+
+## Ziel
+
+Einfaches Mengen-Aufmaß: Monteur erfasst tatsächliche Mengen auf der Baustelle (Handy) oder im Büro (PC/Lieferschein). Geplante vs. tatsächliche Mengen werden verglichen. Tatsächliche Mengen fließen in die Rechnung.
+
+## Architektur
+
+```
+Angebot (offer_items: geplante Mengen)
+         │
+         ▼
+Lieferschein-Item (delivery_note_items)
+  + planned_quantity (aus Angebot)
+  + actual_quantity (vom Monteur gemessen)
+  + measurement_note
+  + measurement_photo_url
+         │
+         ├── Handy: MobileMaterialRecorder (erweitertes Material-Modul)
+         └── PC: DeliveryNoteForm (neuer "Aufmaß" Tab)
+         │
+         ▼
+Rechnung erstellen → übernimmt actual_quantity
+```
+
+## Datenbank
+
+### Tabelle `delivery_note_items` erweitern
+
+| Neue Spalte | Typ | Beschreibung |
+|---|---|---|
+| planned_quantity | decimal(15,3) | Geplante Menge aus Angebot/Auftrag |
+| actual_quantity | decimal(15,3) | Tatsächlich gemessene/verbaute Menge |
+| measurement_note | text | Notiz zum Aufmaß (z.B. "Kabelkanal Flur EG + OG") |
+| measurement_photo_url | text | Foto-URL als Nachweis |
+
+Keine neue Tabelle nötig. Bestehende RLS-Policies greifen.
+
+## Mobile (MobileMaterialRecorder)
+
+### Erweiterung
+
+Das bestehende Material-Erfassungsformular auf dem Handy bekommt:
+
+1. **"Aufmaß" Toggle** — schaltet zwischen normalem Material-Eintrag und Aufmaß-Modus
+2. **Im Aufmaß-Modus:**
+   - Dropdown: Position aus Angebot wählen (lädt geplante Menge + Beschreibung)
+   - Feld "Geplant": zeigt geplante Menge (read-only)
+   - Feld "Tatsächlich": Monteur trägt gemessene Menge ein
+   - Differenz wird automatisch berechnet und farbig angezeigt (grün = gleich, gelb = Abweichung, rot = >20% Abweichung)
+   - Foto-Button für Nachweis (bestehende Kamera-Integration)
+   - Notiz-Feld
+
+## Web/PC (DeliveryNoteForm)
+
+### Neuer Tab "Aufmaß"
+
+Im bestehenden Lieferschein-Formular kommt ein neuer Tab neben "Material" und "Fotos":
+
+**Tab "Aufmaß":**
+- Button "Aus Angebot importieren" → lädt alle offer_items des zugehörigen Projekts
+- Tabelle:
+  | Pos | Beschreibung | Einheit | Geplant | Tatsächlich | Differenz | Foto | Notiz |
+  |-----|-------------|---------|---------|------------|-----------|------|-------|
+  | 1 | Kabelkanal 40x60 | m | 50 | 62 | +12 (24%) | 📷 | Flur EG+OG |
+- Differenz-Spalte: farbig (grün ±5%, gelb ±20%, rot >20%)
+- Einzelne Zeilen können auch manuell hinzugefügt werden
+- Foto-Upload pro Zeile
+
+## Rechnungs-Integration
+
+Beim "Rechnung aus Projekt erstellen" (CreateInvoiceFromProjectDialog):
+- Wenn Aufmaß-Daten vorhanden: `actual_quantity` statt `planned_quantity` verwenden
+- Hinweis anzeigen: "Aufmaß-Daten verfügbar — tatsächliche Mengen werden verwendet"
+- Differenz-Zusammenfassung zeigen bevor Rechnung erstellt wird
+
+## Dateien
+
+### Neue Dateien:
+- `src/components/delivery-notes/AufmassTab.tsx` — Aufmaß-Tab im Lieferschein-Formular
+
+### Zu modifizieren:
+- `src/components/delivery-notes/DeliveryNoteForm.tsx` — Tab hinzufügen
+- `src/components/mobile/MobileMaterialRecorder.tsx` — Aufmaß-Modus
+- `src/components/CreateInvoiceFromProjectDialog.tsx` — actual_quantity verwenden
+
+## Nicht im Scope
+
+- Freihand-Skizzen/Zeichnungen
+- Raum-basiertes Aufmaß (Länge × Breite × Höhe)
+- VOB-konforme Aufmaß-Blätter (DIN 18299)
+- Automatische Mengenermittlung aus Fotos/Plänen
+- LV-Import (Leistungsverzeichnis)

--- a/src/components/CreateInvoiceFromProjectDialog.tsx
+++ b/src/components/CreateInvoiceFromProjectDialog.tsx
@@ -24,7 +24,8 @@ import {
   ChevronRight,
   Check,
   AlertCircle,
-  Euro
+  Euro,
+  Ruler
 } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/hooks/use-toast";
@@ -114,6 +115,8 @@ const CreateInvoiceFromProjectDialog: React.FC<CreateInvoiceFromProjectDialogPro
   const [deliveryNotes, setDeliveryNotes] = useState<DeliveryNoteData[]>([]);
   const [timeEntries, setTimeEntries] = useState<TimeEntryData[]>([]);
   const [projectMaterials, setProjectMaterials] = useState<ProjectMaterialData[]>([]);
+  // Aufmaß: map from offer item description to actual_quantity
+  const [aufmassMap, setAufmassMap] = useState<Record<string, number>>({});
 
   // Selections
   const [selectedOffers, setSelectedOffers] = useState<string[]>([]);
@@ -282,6 +285,22 @@ const CreateInvoiceFromProjectDialog: React.FC<CreateInvoiceFromProjectDialogPro
       }));
       setProjectMaterials(processedMat);
 
+      // Load Aufmaß data: delivery_note_items with actual_quantity set
+      // These are linked to delivery_notes for this project
+      const { data: aufmassData } = await supabase
+        .from('delivery_note_items')
+        .select('material_name, actual_quantity, delivery_note_id, delivery_notes!inner(project_id)')
+        .eq('delivery_notes.project_id', projectId)
+        .not('actual_quantity', 'is', null) as { data: Array<{ material_name: string | null; actual_quantity: number }> | null };
+
+      const newAufmassMap: Record<string, number> = {};
+      (aufmassData || []).forEach((item) => {
+        if (item.material_name && item.actual_quantity != null) {
+          newAufmassMap[item.material_name] = item.actual_quantity;
+        }
+      });
+      setAufmassMap(newAufmassMap);
+
     } catch (error) {
       console.error('Error loading project data:', error);
       toast({
@@ -306,13 +325,14 @@ const CreateInvoiceFromProjectDialog: React.FC<CreateInvoiceFromProjectDialogPro
   const calculateTotals = () => {
     let netTotal = 0;
 
-    // From offers
+    // From offers (use Aufmaß actual_quantity when available)
     if (includeOfferItems) {
       selectedOffers.forEach(offerId => {
         const offer = offers.find(o => o.id === offerId);
         if (offer) {
           offer.items.forEach(item => {
-            netTotal += item.quantity * item.unit_price_net;
+            const qty = aufmassMap[item.description] ?? item.quantity;
+            netTotal += qty * item.unit_price_net;
           });
         }
       });
@@ -435,19 +455,21 @@ const CreateInvoiceFromProjectDialog: React.FC<CreateInvoiceFromProjectDialogPro
       let positionNumber = 1;
 
       // 1. Offer items first (contract items, no date grouping)
+      //    Use Aufmaß actual_quantity when available
       if (includeOfferItems) {
         selectedOffers.forEach(offerId => {
           const offer = offers.find(o => o.id === offerId);
           if (offer) {
             offer.items.forEach(item => {
+              const qty = aufmassMap[item.description] ?? item.quantity;
               docItems.push({
                 invoice_id: invoiceData.id,
                 position: positionNumber++,
                 description: item.description,
-                quantity: item.quantity,
+                quantity: qty,
                 unit: item.unit,
                 unit_price: item.unit_price_net,
-                total_price: item.quantity * item.unit_price_net,
+                total_price: qty * item.unit_price_net,
                 company_id: companyId
               });
             });
@@ -752,6 +774,14 @@ const CreateInvoiceFromProjectDialog: React.FC<CreateInvoiceFromProjectDialogPro
                 2. Konfigurieren
               </span>
             </div>
+
+            {/* Aufmaß info banner */}
+            {Object.keys(aufmassMap).length > 0 && (
+              <div className="flex items-center gap-2 rounded-lg border border-blue-200 bg-blue-50 px-4 py-2.5 text-sm text-blue-800">
+                <Ruler className="h-4 w-4 flex-shrink-0 text-blue-600" />
+                <span>{"Aufmaß-Daten vorhanden \u2014 tatsächliche Mengen werden verwendet"}</span>
+              </div>
+            )}
 
             {step === 'select' && (
               <>

--- a/src/components/delivery-notes/AufmassTab.tsx
+++ b/src/components/delivery-notes/AufmassTab.tsx
@@ -1,0 +1,317 @@
+// AufmassTab — planned vs actual quantity table for delivery notes
+
+import { useState } from 'react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Download, Plus, Trash2 } from 'lucide-react';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from 'sonner';
+
+export interface AufmassItem {
+  id?: string;
+  description: string;
+  unit: string;
+  planned_quantity: number | null;
+  actual_quantity: number | null;
+  measurement_note: string;
+  measurement_photo_url: string | null;
+}
+
+interface AufmassTabProps {
+  projectId: string | null;
+  items: AufmassItem[];
+  onItemsChange: (items: AufmassItem[]) => void;
+}
+
+/**
+ * Returns color class based on deviation between planned and actual quantity.
+ * Green: within ±5%, Amber: within ±20%, Red: >20%
+ */
+function deviationColor(planned: number | null, actual: number | null): string {
+  if (planned == null || actual == null || planned === 0) return '';
+  const pct = Math.abs((actual - planned) / planned) * 100;
+  if (pct <= 5) return 'text-green-600 dark:text-green-400';
+  if (pct <= 20) return 'text-amber-600 dark:text-amber-400';
+  return 'text-red-600 dark:text-red-400';
+}
+
+function deviationBadgeVariant(planned: number | null, actual: number | null): 'default' | 'secondary' | 'destructive' | 'outline' {
+  if (planned == null || actual == null || planned === 0) return 'outline';
+  const pct = Math.abs((actual - planned) / planned) * 100;
+  if (pct <= 5) return 'default';      // green-ish (default badge)
+  if (pct <= 20) return 'secondary';   // amber-ish
+  return 'destructive';                // red
+}
+
+export function AufmassTab({ projectId, items, onItemsChange }: AufmassTabProps) {
+  const [importing, setImporting] = useState(false);
+
+  // Import offer items for the project
+  const handleImportFromOffer = async () => {
+    if (!projectId) {
+      toast.error('Bitte zuerst ein Projekt auswählen.');
+      return;
+    }
+
+    setImporting(true);
+    try {
+      // Load offers for this project, then their items
+      const { data: offers, error: offersError } = await supabase
+        .from('offers')
+        .select('id')
+        .eq('project_id', projectId)
+        .in('status', ['accepted', 'sent']);
+
+      if (offersError) throw offersError;
+
+      if (!offers || offers.length === 0) {
+        toast.info('Keine Angebote für dieses Projekt gefunden.');
+        return;
+      }
+
+      const offerIds = offers.map(o => o.id);
+
+      const { data: offerItems, error: itemsError } = await supabase
+        .from('offer_items')
+        .select('description, quantity, unit, position_number')
+        .in('offer_id', offerIds)
+        .order('position_number');
+
+      if (itemsError) throw itemsError;
+
+      if (!offerItems || offerItems.length === 0) {
+        toast.info('Keine Positionen in den Angeboten gefunden.');
+        return;
+      }
+
+      // Map offer items to AufmassItems, keeping existing items
+      const newItems: AufmassItem[] = offerItems.map(oi => ({
+        description: oi.description,
+        unit: oi.unit,
+        planned_quantity: oi.quantity,
+        actual_quantity: null,
+        measurement_note: '',
+        measurement_photo_url: null,
+      }));
+
+      // Merge: keep existing items, append new ones that don't already exist (by description)
+      const existingDescriptions = new Set(items.map(i => i.description));
+      const toAdd = newItems.filter(ni => !existingDescriptions.has(ni.description));
+
+      if (toAdd.length === 0) {
+        toast.info('Alle Angebotspositionen sind bereits vorhanden.');
+        return;
+      }
+
+      onItemsChange([...items, ...toAdd]);
+      toast.success(`${toAdd.length} Position(en) aus Angebot importiert.`);
+    } catch (err) {
+      console.error('Import from offer failed:', err);
+      toast.error('Fehler beim Import der Angebotspositionen.');
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  // Add a manual row
+  const addManualRow = () => {
+    onItemsChange([
+      ...items,
+      {
+        description: '',
+        unit: 'Stk',
+        planned_quantity: null,
+        actual_quantity: null,
+        measurement_note: '',
+        measurement_photo_url: null,
+      },
+    ]);
+  };
+
+  // Update a single field on an item
+  const updateItem = (index: number, field: keyof AufmassItem, value: any) => {
+    const updated = [...items];
+    updated[index] = { ...updated[index], [field]: value };
+    onItemsChange(updated);
+  };
+
+  // Remove an item
+  const removeItem = (index: number) => {
+    onItemsChange(items.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Action buttons */}
+      <div className="flex gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          className="flex-1"
+          disabled={importing || !projectId}
+          onClick={handleImportFromOffer}
+        >
+          <Download className="h-4 w-4 mr-2" />
+          {importing ? 'Wird importiert...' : 'Aus Angebot importieren'}
+        </Button>
+        <Button type="button" variant="outline" onClick={addManualRow}>
+          <Plus className="h-4 w-4 mr-2" />
+          Zeile hinzufügen
+        </Button>
+      </div>
+
+      {items.length === 0 ? (
+        <p className="text-sm text-muted-foreground text-center py-4">
+          Noch keine Aufmaß-Positionen. Importieren Sie aus einem Angebot oder fügen Sie manuell hinzu.
+        </p>
+      ) : (
+        <Card>
+          <CardContent className="p-0">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-12">Pos</TableHead>
+                  <TableHead>Beschreibung</TableHead>
+                  <TableHead className="w-20">Einheit</TableHead>
+                  <TableHead className="w-20 text-right">Geplant</TableHead>
+                  <TableHead className="w-24 text-right">Tatsächlich</TableHead>
+                  <TableHead className="w-24 text-right">Differenz</TableHead>
+                  <TableHead className="w-40">Notiz</TableHead>
+                  <TableHead className="w-10"></TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {items.map((item, index) => {
+                  const diff =
+                    item.planned_quantity != null && item.actual_quantity != null
+                      ? item.actual_quantity - item.planned_quantity
+                      : null;
+                  const diffPct =
+                    diff != null && item.planned_quantity != null && item.planned_quantity !== 0
+                      ? ((diff / item.planned_quantity) * 100).toFixed(0)
+                      : null;
+
+                  return (
+                    <TableRow key={index}>
+                      {/* Pos */}
+                      <TableCell className="text-muted-foreground text-xs">
+                        {index + 1}
+                      </TableCell>
+
+                      {/* Beschreibung */}
+                      <TableCell>
+                        {item.planned_quantity != null ? (
+                          <span className="text-sm">{item.description}</span>
+                        ) : (
+                          <Input
+                            value={item.description}
+                            onChange={(e) => updateItem(index, 'description', e.target.value)}
+                            placeholder="Beschreibung..."
+                            className="h-8 text-sm"
+                          />
+                        )}
+                      </TableCell>
+
+                      {/* Einheit */}
+                      <TableCell>
+                        {item.planned_quantity != null ? (
+                          <span className="text-sm text-muted-foreground">{item.unit}</span>
+                        ) : (
+                          <Input
+                            value={item.unit}
+                            onChange={(e) => updateItem(index, 'unit', e.target.value)}
+                            placeholder="Stk"
+                            className="h-8 text-sm w-16"
+                          />
+                        )}
+                      </TableCell>
+
+                      {/* Geplant */}
+                      <TableCell className="text-right text-sm">
+                        {item.planned_quantity != null ? (
+                          item.planned_quantity
+                        ) : (
+                          <Input
+                            type="number"
+                            value={item.planned_quantity ?? ''}
+                            onChange={(e) =>
+                              updateItem(index, 'planned_quantity', e.target.value ? Number(e.target.value) : null)
+                            }
+                            placeholder="—"
+                            className="h-8 text-sm text-right w-16"
+                          />
+                        )}
+                      </TableCell>
+
+                      {/* Tatsächlich */}
+                      <TableCell className="text-right">
+                        <Input
+                          type="number"
+                          value={item.actual_quantity ?? ''}
+                          onChange={(e) =>
+                            updateItem(index, 'actual_quantity', e.target.value ? Number(e.target.value) : null)
+                          }
+                          placeholder="—"
+                          className="h-8 text-sm text-right w-20"
+                        />
+                      </TableCell>
+
+                      {/* Differenz */}
+                      <TableCell className="text-right">
+                        {diff != null ? (
+                          <Badge variant={deviationBadgeVariant(item.planned_quantity, item.actual_quantity)}>
+                            <span className={deviationColor(item.planned_quantity, item.actual_quantity)}>
+                              {diff > 0 ? '+' : ''}{diff} {item.unit}
+                              {diffPct != null && ` (${diffPct}%)`}
+                            </span>
+                          </Badge>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">—</span>
+                        )}
+                      </TableCell>
+
+                      {/* Notiz */}
+                      <TableCell>
+                        <Textarea
+                          value={item.measurement_note}
+                          onChange={(e) => updateItem(index, 'measurement_note', e.target.value)}
+                          placeholder="Notiz..."
+                          className="h-8 min-h-[32px] text-sm resize-none"
+                          rows={1}
+                        />
+                      </TableCell>
+
+                      {/* Delete */}
+                      <TableCell>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7 text-destructive"
+                          onClick={() => removeItem(index)}
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/components/delivery-notes/DeliveryNoteForm.tsx
+++ b/src/components/delivery-notes/DeliveryNoteForm.tsx
@@ -21,8 +21,9 @@ import {
 } from '@/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Card, CardContent } from '@/components/ui/card';
-import { Plus, Trash2, Camera, Package, Clock, Save, AlertTriangle, Info, Users, Euro, X } from 'lucide-react';
+import { Plus, Trash2, Camera, Package, Clock, Save, AlertTriangle, Info, Users, Euro, X, Ruler } from 'lucide-react';
 import { useDeliveryNotes, type DeliveryNote } from '@/hooks/useDeliveryNotes';
+import { AufmassTab, type AufmassItem } from './AufmassTab';
 import { useSupabaseAuth } from '@/hooks/useSupabaseAuth';
 import { supabase } from '@/integrations/supabase/client';
 
@@ -108,6 +109,7 @@ export function DeliveryNoteForm({
 
   const [materials, setMaterials] = useState<MaterialItem[]>([]);
   const [photos, setPhotos] = useState<PhotoItem[]>([]);
+  const [aufmassItems, setAufmassItems] = useState<AufmassItem[]>([]);
   const [activeTab, setActiveTab] = useState('details');
   const [submitting, setSubmitting] = useState(false);
   const [uploadingPhoto, setUploadingPhoto] = useState(false);
@@ -265,6 +267,7 @@ export function DeliveryNoteForm({
       });
       setMaterials([]);
       setPhotos([]);
+      setAufmassItems([]);
       setSelectedEmployeeIds([]);
       setActiveTab('details');
     }
@@ -510,7 +513,7 @@ export function DeliveryNoteForm({
         </div>
 
         <Tabs value={activeTab} onValueChange={setActiveTab}>
-          <TabsList className="grid w-full grid-cols-3">
+          <TabsList className="grid w-full grid-cols-4">
             <TabsTrigger value="details" className="flex items-center gap-2">
               <Clock className="h-4 w-4" />
               Arbeitszeit
@@ -523,6 +526,10 @@ export function DeliveryNoteForm({
                   {materialBrutto.toFixed(0)}€
                 </span>
               )}
+            </TabsTrigger>
+            <TabsTrigger value="aufmass" className="flex items-center gap-2">
+              <Ruler className="h-4 w-4" />
+              Aufmaß ({aufmassItems.length})
             </TabsTrigger>
             <TabsTrigger value="photos" className="flex items-center gap-2">
               <Camera className="h-4 w-4" />
@@ -930,6 +937,15 @@ export function DeliveryNoteForm({
                 )}
               </div>
             )}
+          </TabsContent>
+
+          {/* ---- AUFMASS TAB ---- */}
+          <TabsContent value="aufmass" className="space-y-4 mt-4 min-h-[600px]">
+            <AufmassTab
+              projectId={selectedProjectId || null}
+              items={aufmassItems}
+              onItemsChange={setAufmassItems}
+            />
           </TabsContent>
 
           {/* ---- PHOTOS TAB ---- */}

--- a/src/components/mobile/MobileMaterialRecorder.tsx
+++ b/src/components/mobile/MobileMaterialRecorder.tsx
@@ -1,10 +1,11 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useMemo } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { Badge } from "@/components/ui/badge"
+import { Switch } from "@/components/ui/switch"
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet"
 import {
   Package,
@@ -16,12 +17,25 @@ import {
   AlertTriangle,
   Camera,
   Boxes,
-  TrendingDown
+  TrendingDown,
+  Ruler
 } from "lucide-react"
 import { useMaterials } from "@/hooks/useMaterials"
 import { toast } from "sonner"
 import { Geolocation } from '@capacitor/geolocation'
 import { Camera as CapacitorCamera, CameraResultType } from '@capacitor/camera'
+
+/**
+ * Computes the deviation color class between planned and actual quantities.
+ * Green: within +/-5%, Amber: within +/-20%, Red: >20%
+ */
+function getDeviationColor(planned: number, actual: number): { bg: string; text: string; label: string } {
+  if (planned <= 0) return { bg: 'bg-gray-50', text: 'text-gray-600', label: '' }
+  const deviation = Math.abs((actual - planned) / planned)
+  if (deviation <= 0.05) return { bg: 'bg-green-50', text: 'text-green-700', label: 'Im Rahmen' }
+  if (deviation <= 0.20) return { bg: 'bg-amber-50', text: 'text-amber-700', label: 'Abweichung' }
+  return { bg: 'bg-red-50', text: 'text-red-700', label: 'Starke Abweichung' }
+}
 
 interface MobileMaterialRecorderProps {
   projectId: string
@@ -54,6 +68,21 @@ const MobileMaterialRecorder: React.FC<MobileMaterialRecorderProps> = ({
   const [showConfirm, setShowConfirm] = useState(false)
   const [currentLocation, setCurrentLocation] = useState<{ lat: number; lng: number } | null>(null)
   const [photoData, setPhotoData] = useState<string | null>(null)
+
+  // Aufmass mode state
+  const [aufmassMode, setAufmassMode] = useState(false)
+  const [plannedQuantity, setPlannedQuantity] = useState('')
+  const [measurementNote, setMeasurementNote] = useState('')
+
+  // Deviation indicator for Aufmass mode
+  const deviation = useMemo(() => {
+    const planned = parseFloat(plannedQuantity)
+    const actual = parseFloat(quantity)
+    if (aufmassMode && !isNaN(planned) && !isNaN(actual) && planned > 0) {
+      return getDeviationColor(planned, actual)
+    }
+    return null
+  }, [aufmassMode, plannedQuantity, quantity])
 
   // Get filtered materials
   const filteredMaterials = searchQuery ? searchMaterials(searchQuery) : materials
@@ -117,16 +146,31 @@ const MobileMaterialRecorder: React.FC<MobileMaterialRecorderProps> = ({
       return
     }
 
-    const result = await recordMaterialUsage({
+    // Build notes: append measurement note if in Aufmass mode
+    const combinedNotes = aufmassMode && measurementNote
+      ? (notes ? `${notes} | Aufmass: ${measurementNote}` : `Aufmass: ${measurementNote}`)
+      : notes || undefined
+
+    const usageData: Record<string, unknown> = {
       project_id: projectId,
       material_id: selectedMaterial.id,
       employee_id: '', // Will be set in hook
       quantity: quantityNum,
       unit_price: selectedMaterial.unit_price,
-      notes: notes || undefined,
+      notes: combinedNotes,
       used_at: new Date().toISOString(),
-      location: currentLocation || undefined
-    })
+      location: currentLocation || undefined,
+    }
+
+    // Include Aufmass data when mode is active
+    if (aufmassMode) {
+      const plannedNum = parseFloat(plannedQuantity)
+      usageData.planned_quantity = isNaN(plannedNum) ? undefined : plannedNum
+      usageData.actual_quantity = quantityNum
+      usageData.measurement_note = measurementNote || undefined
+    }
+
+    const result = await recordMaterialUsage(usageData as any)
 
     if (result.success) {
       // Reset form
@@ -135,6 +179,8 @@ const MobileMaterialRecorder: React.FC<MobileMaterialRecorderProps> = ({
       setNotes('')
       setShowConfirm(false)
       setPhotoData(null)
+      setPlannedQuantity('')
+      setMeasurementNote('')
 
       if (onMaterialAdded) {
         onMaterialAdded()
@@ -152,6 +198,8 @@ const MobileMaterialRecorder: React.FC<MobileMaterialRecorderProps> = ({
     setNotes('')
     setShowConfirm(false)
     setPhotoData(null)
+    setPlannedQuantity('')
+    setMeasurementNote('')
   }
 
   return (
@@ -279,9 +327,49 @@ const MobileMaterialRecorder: React.FC<MobileMaterialRecorderProps> = ({
                   </CardContent>
                 </Card>
 
+                {/* Aufmass Toggle */}
+                <div className="flex items-center justify-between rounded-lg border p-3">
+                  <div className="flex items-center gap-2">
+                    <Ruler className="h-4 w-4 text-gray-600" />
+                    <Label htmlFor="aufmass-mode" className="cursor-pointer font-medium">
+                      Aufmaß-Modus
+                    </Label>
+                  </div>
+                  <Switch
+                    id="aufmass-mode"
+                    checked={aufmassMode}
+                    onCheckedChange={setAufmassMode}
+                  />
+                </div>
+
                 <div className="space-y-3">
+                  {/* Aufmass: Geplant (read-only planned quantity) */}
+                  {aufmassMode && (
+                    <div>
+                      <Label htmlFor="planned-quantity">Geplant</Label>
+                      <div className="flex gap-2 mt-1">
+                        <Input
+                          id="planned-quantity"
+                          type="number"
+                          inputMode="decimal"
+                          step="any"
+                          placeholder="Geplante Menge"
+                          value={plannedQuantity}
+                          onChange={(e) => setPlannedQuantity(e.target.value)}
+                          className="flex-1 bg-gray-50"
+                        />
+                        <div className="flex items-center px-3 bg-gray-100 rounded-md">
+                          <span className="text-sm font-medium">{selectedMaterial.unit}</span>
+                        </div>
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Quantity / Tatsaechlich */}
                   <div>
-                    <Label htmlFor="quantity">Menge *</Label>
+                    <Label htmlFor="quantity">
+                      {aufmassMode ? 'Tatsächlich *' : 'Menge *'}
+                    </Label>
                     <div className="flex gap-2 mt-1">
                       <Input
                         id="quantity"
@@ -298,6 +386,42 @@ const MobileMaterialRecorder: React.FC<MobileMaterialRecorderProps> = ({
                       </div>
                     </div>
                   </div>
+
+                  {/* Aufmass deviation indicator */}
+                  {aufmassMode && deviation && (
+                    <Card className={`${deviation.bg} border-0`}>
+                      <CardContent className="p-3">
+                        <div className={`flex items-center justify-between text-sm ${deviation.text}`}>
+                          <span className="font-medium">{deviation.label}</span>
+                          <span>
+                            {(() => {
+                              const planned = parseFloat(plannedQuantity)
+                              const actual = parseFloat(quantity)
+                              if (isNaN(planned) || planned <= 0 || isNaN(actual)) return ''
+                              const pct = ((actual - planned) / planned) * 100
+                              const sign = pct >= 0 ? '+' : ''
+                              return `${sign}${pct.toFixed(1)}%`
+                            })()}
+                          </span>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  )}
+
+                  {/* Aufmass: measurement note */}
+                  {aufmassMode && (
+                    <div>
+                      <Label htmlFor="measurement-note">Notiz (Aufmaß)</Label>
+                      <Textarea
+                        id="measurement-note"
+                        placeholder="z.B. Abweichungsgrund, Nachbestellung nötig..."
+                        value={measurementNote}
+                        onChange={(e) => setMeasurementNote(e.target.value)}
+                        className="mt-1"
+                        rows={2}
+                      />
+                    </div>
+                  )}
 
                   <div>
                     <Label htmlFor="notes">Notizen (optional)</Label>


### PR DESCRIPTION
## Summary
- New Aufmaß columns on delivery_note_items (planned_quantity, actual_quantity, measurement_note, measurement_photo_url)
- AufmassTab component in DeliveryNoteForm with "Aus Angebot importieren" and deviation color-coding
- Aufmaß mode toggle in MobileMaterialRecorder for on-site measurement
- Invoice creation uses actual_quantity when Aufmaß data exists

## Test plan
- [ ] Create delivery note → Aufmaß tab → import from offer → enter actual quantities
- [ ] Mobile: toggle Aufmaß mode → enter planned/actual → verify color-coding
- [ ] Create invoice from project with Aufmaß data → verify actual quantities used

🤖 Generated with [Claude Code](https://claude.com/claude-code)