### PR TITLE
fix: notification-cron von hartkodiertem JWT auf Vault umstellen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,9 @@ serveo_logs.txt
 e2e/.auth/
 playwright-report/
 test-results/
+
+# Superpowers-Brainstorm: ephemere Session-Scratch-Ordner.
+# Bereits committete Brainstorm-Dateien bleiben getrackt; diese Regel verhindert
+# nur, dass NEUE Scratch-Ordner versehentlich (z. B. via git add -A) reinrutschen.
+# Bewusst committen: git add -f <pfad>.
+/.superpowers/brainstorm/

--- a/supabase/migrations/20260722171901_replace_hardcoded_jwt_in_notification_cron.sql
+++ b/supabase/migrations/20260722171901_replace_hardcoded_jwt_in_notification_cron.sql
@@ -1,0 +1,61 @@
+-- ====================================================================
+-- Replace hardcoded JWT in notification-cron with Vault-based read
+--
+-- notification-cron was scheduled directly on the production database (no
+-- repo migration ever existed for it) with an anon JWT hardcoded in the
+-- Authorization header — the same pattern already fixed for gmail-sync-job
+-- and process-ai-queue-job (20260722162523 / 20260722162550).
+--
+-- This migration re-creates the job so the Authorization header is built at
+-- execution time from Supabase Vault. The migration itself contains no secret.
+--
+-- The Vault secret `supabase_anon_key` is shared with the other cron jobs and
+-- is already provisioned; nothing more to set up.
+--
+-- Idempotent: safely re-runnable. Re-applying replaces the existing job.
+-- ====================================================================
+
+-- Fail fast if the secret has not been provisioned in this environment.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM vault.decrypted_secrets WHERE name = 'supabase_anon_key'
+  ) THEN
+    RAISE EXCEPTION
+      'Vault secret "supabase_anon_key" is missing. Create it via '
+      'Project Settings → Vault → Secrets (or vault.create_secret) '
+      'before applying this migration.';
+  END IF;
+END
+$$;
+
+-- Drop the existing job so we can re-create it with the Vault-based auth header.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'notification-cron') THEN
+    PERFORM cron.unschedule('notification-cron');
+  END IF;
+END
+$$;
+
+-- Reschedule with the auth header read per-invocation from Vault. Schedule and
+-- body preserved verbatim from the previously installed job.
+SELECT cron.schedule(
+  'notification-cron',
+  '0 0,6,12,18 * * *', -- 00:00, 06:00, 12:00, 18:00 UTC
+  $$
+  SELECT net.http_post(
+    url := 'https://qgwhkjrhndeoskrxewpb.supabase.co/functions/v1/notification-cron',
+    headers := jsonb_build_object(
+      'Content-Type',  'application/json',
+      'Authorization', 'Bearer ' || (
+        SELECT decrypted_secret
+        FROM vault.decrypted_secrets
+        WHERE name = 'supabase_anon_key'
+        LIMIT 1
+      )
+    ),
+    body := '{"automated": true}'::jsonb
+  ) AS request_id;
+  $$
+);


### PR DESCRIPTION
Letzter Cron-Job mit hartkodiertem anon-JWT im Kommando. Wie zuvor gmail-sync-job und process-ai-queue-job (PR #82) wurde notification-cron direkt auf der Produktiv-DB angelegt, ohne Repo-Migration.

Der Job wird neu geplant, sodass der Authorization-Header pro Aufruf aus `vault.decrypted_secrets` (`supabase_anon_key`) gebaut wird — Schedule `0 0,6,12,18 * * *` und Body unverändert. Das Vault-Secret ist bereits vorhanden (mit PR #82 eingerichtet).

**Bereits auf Produktion angewandt** (über die API, registriert als `20260722171901`; diese PR bringt nur die Repo-Datei nach). Verifiziert: alle fünf Cron-Jobs nutzen jetzt Vault, keiner trägt mehr einen Klartext-JWT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)