### PR TITLE
feat: Soll-Kostenbasis für Angebote und Projekte

### DIFF
--- a/docs/superpowers/plans/2026-07-22-soll-kostenbasis.md
+++ b/docs/superpowers/plans/2026-07-22-soll-kostenbasis.md
@@ -1,0 +1,454 @@
+# Soll-Kostenbasis Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Aus den Positionen eines Angebots entsteht eine strukturierte, eingefrorene Soll-Kostenbasis (Erlös, Kosten, Marge), die beim Annehmen zum Projektbudget wird.
+
+**Architecture:** Eine SQL-Funktion `get_offer_cost_basis(offer_id)` ist die *einzige autoritative* Quelle der Zahlen; ein BEFORE-UPDATE-Trigger auf `offers` friert sie beim Übergang draft→sent/accepted in `offer_targets` ein (trifft beide Versandpfade — Service und Edge Function). Eine spiegelbildliche TS-Funktion `computeOfferCostBasis` liefert dieselbe Rechnung für die Live-Marge im Editor (unsaved State); ein Paritätstest hält beide deckungsgleich.
+
+**Tech Stack:** Supabase/Postgres (plpgsql), TypeScript, React, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-07-22-soll-kostenbasis-design.md`
+
+---
+
+## File Structure
+
+- `supabase/migrations/<ts>_offer_cost_basis.sql` — neue Spalte `cost_rate_snapshot`, Funktion `get_offer_cost_basis`, Freeze-Trigger.
+- `src/lib/offerCostBasis.ts` — reine TS-Rechnung (Kostensatz-Anwendung, Positions- und Summenlogik, Marge, Vollständigkeit).
+- `src/lib/offerCostBasis.test.ts` — Unit-Tests inkl. Paritäts-Fixture gegen die SQL-Definition.
+- `src/components/offers/OfferSummaryCard.tsx` — Live-Marge-Anzeige.
+- `supabase/migrations/<ts>_accept_offer_drop_description_markers.sql` — `accept_offer_and_create_project` ohne Freitext-Marker.
+
+---
+
+## Task 1: Migration — Spalte, Kostenbasis-Funktion, Freeze-Trigger
+
+**Files:**
+- Create: `supabase/migrations/20260722180000_offer_cost_basis.sql`
+
+**Kontext:** Kostensatz = `amge_calculations.lohn_mit_agk` der aktiven Zeile (Vollkosten/h, Kostenseite). Fallback `company_settings.default_tax_rate` gibt es NICHT als Satz — Fallback ist `company_ai_settings.default_hourly_rate`; sonst NULL (= keine Kostenbasis). Positions-Kostenbasis „bekannt", wenn `planned_hours_item IS NOT NULL OR material_purchase_cost IS NOT NULL`.
+
+- [ ] **Step 1: Migration schreiben**
+
+```sql
+-- Soll-Kostenbasis: Spalte, autoritative Berechnungsfunktion, Freeze-Trigger.
+-- Siehe docs/superpowers/specs/2026-07-22-soll-kostenbasis-design.md
+
+-- 1. Reproduzierbarkeit des eingefrorenen Kostensatzes (§10)
+ALTER TABLE public.offer_targets
+  ADD COLUMN IF NOT EXISTS cost_rate_snapshot NUMERIC;
+COMMENT ON COLUMN public.offer_targets.cost_rate_snapshot IS
+  'Interner Vollkosten-Stundensatz (amge_calculations.lohn_mit_agk) zum Einfrierzeitpunkt.';
+
+-- 2. Einzige autoritative Quelle der Soll-Zahlen eines Angebots.
+--    Gibt Erlös immer zurück; Kosten/Marge/Satz nur bei vollständiger Kostenbasis.
+CREATE OR REPLACE FUNCTION public.get_offer_cost_basis(p_offer_id UUID)
+RETURNS TABLE (
+  revenue      NUMERIC,
+  cost         NUMERIC,
+  margin_pct   NUMERIC,
+  cost_rate    NUMERIC,
+  is_complete  BOOLEAN
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_company_id UUID;
+  v_rate       NUMERIC;
+  v_revenue    NUMERIC;
+  v_cost       NUMERIC;
+  v_complete   BOOLEAN;
+BEGIN
+  SELECT company_id INTO v_company_id FROM public.offers WHERE id = p_offer_id;
+
+  -- Kostensatz: aktive AMGE (gültig heute), sonst Fallback, sonst NULL
+  SELECT a.lohn_mit_agk INTO v_rate
+  FROM public.amge_calculations a
+  WHERE a.company_id = v_company_id AND a.is_active
+    AND (a.valid_from IS NULL OR a.valid_from <= CURRENT_DATE)
+    AND (a.valid_until IS NULL OR a.valid_until >= CURRENT_DATE)
+  ORDER BY a.valid_from DESC NULLS LAST
+  LIMIT 1;
+
+  IF v_rate IS NULL THEN
+    SELECT default_hourly_rate INTO v_rate
+    FROM public.company_ai_settings WHERE company_id = v_company_id LIMIT 1;
+  END IF;
+
+  SELECT
+    COALESCE(SUM(oi.quantity * oi.unit_price_net), 0),
+    SUM(COALESCE(oi.planned_hours_item, 0) * COALESCE(v_rate, 0)
+        + COALESCE(oi.material_purchase_cost, 0)),
+    bool_and(oi.planned_hours_item IS NOT NULL OR oi.material_purchase_cost IS NOT NULL)
+  INTO v_revenue, v_cost, v_complete
+  FROM public.offer_items oi
+  WHERE oi.offer_id = p_offer_id;
+
+  -- kein Kostensatz -> Kostenbasis gilt als unvollständig
+  IF v_rate IS NULL THEN
+    v_complete := false;
+  END IF;
+
+  -- leeres Angebot: keine vollständige Basis
+  v_complete := COALESCE(v_complete, false);
+
+  revenue     := v_revenue;
+  cost        := CASE WHEN v_complete THEN v_cost ELSE NULL END;
+  margin_pct  := CASE WHEN v_complete AND v_revenue > 0
+                      THEN round((v_revenue - v_cost) / v_revenue * 100, 2) ELSE NULL END;
+  cost_rate   := CASE WHEN v_complete THEN v_rate ELSE NULL END;
+  is_complete := v_complete;
+  RETURN NEXT;
+END;
+$$;
+
+-- 3. Freeze-Trigger: friert die Soll-Werte beim Übergang draft->sent/accepted
+--    in offer_targets ein. Trifft beide Versandpfade. Ueberschreibt einen
+--    bestehenden Snapshot NICHT (GoBD/§10).
+CREATE OR REPLACE FUNCTION public.freeze_offer_target_snapshot()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+DECLARE
+  v_basis RECORD;
+BEGIN
+  IF TG_OP = 'UPDATE' AND OLD.status = 'draft'
+     AND NEW.status IN ('sent', 'accepted') THEN
+
+    SELECT * INTO v_basis FROM public.get_offer_cost_basis(NEW.id);
+
+    -- offer_targets-Zeile sicherstellen (manche Angebote haben keine)
+    INSERT INTO public.offer_targets (offer_id)
+    VALUES (NEW.id)
+    ON CONFLICT (offer_id) DO NOTHING;
+
+    UPDATE public.offer_targets ot
+    SET snapshot_target_revenue = v_basis.revenue,
+        snapshot_target_cost    = v_basis.cost,
+        snapshot_target_margin  = v_basis.margin_pct,
+        cost_rate_snapshot      = v_basis.cost_rate,
+        snapshot_created_at     = NOW(),
+        updated_at              = NOW()
+    WHERE ot.offer_id = NEW.id
+      AND ot.snapshot_created_at IS NULL; -- bestehende Snapshots unberührt
+
+    RETURN NEW;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS freeze_offer_target_snapshot_trigger ON public.offers;
+CREATE TRIGGER freeze_offer_target_snapshot_trigger
+  BEFORE UPDATE ON public.offers
+  FOR EACH ROW
+  EXECUTE FUNCTION public.freeze_offer_target_snapshot();
+```
+
+- [ ] **Step 2: Voraussetzung prüfen — UNIQUE auf offer_targets.offer_id**
+
+Der `ON CONFLICT (offer_id)` braucht einen Unique-Constraint. Prüfen:
+
+Run: `docker exec supabase_db_qgwhkjrhndeoskrxewpb psql -U postgres -d postgres -c "select conname, pg_get_constraintdef(oid) from pg_constraint where conrelid='public.offer_targets'::regclass and contype in ('u','p');"`
+Expected: eine UNIQUE/PK auf `(offer_id)`. Fehlt sie, in der Migration VOR Schritt 3 ergänzen:
+```sql
+ALTER TABLE public.offer_targets
+  ADD CONSTRAINT offer_targets_offer_id_key UNIQUE (offer_id);
+```
+
+- [ ] **Step 3: Lokal anwenden und Kostenbasis-Funktion testen**
+
+Run (Vault-Migrationen ggf. beiseitelegen wie in der Repo-Historie üblich, dann):
+`npx supabase db reset`
+Danach mit einem Fixture-Angebot (1 Position: quantity 10, unit_price_net 85, planned_hours_item 10, material_purchase_cost 200) und aktiver AMGE (lohn_mit_agk 40) gegen die Funktion:
+`docker exec ... psql -c "select * from public.get_offer_cost_basis('<offer_id>');"`
+Expected: `revenue=850, cost=600, margin_pct≈29.41, cost_rate=40, is_complete=t`.
+
+- [ ] **Step 4: Freeze-Verhalten testen (SQL, in Transaktion)**
+
+Fixture-Angebot draft→sent updaten, dann `offer_targets` prüfen: Snapshot-Felder + `cost_rate_snapshot` gesetzt. Zweites Update sent→accepted: Snapshot unverändert (kein Überschreiben). Position ohne Kosten: `snapshot_target_cost/-margin/cost_rate_snapshot` bleiben NULL, `snapshot_target_revenue` gesetzt.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/migrations/20260722180000_offer_cost_basis.sql
+git commit -m "feat: Soll-Kostenbasis — Funktion und Freeze-Trigger auf offer_targets"
+```
+
+---
+
+## Task 2: TS-Rechnung für die Live-Marge
+
+**Files:**
+- Create: `src/lib/offerCostBasis.ts`
+- Test: `src/lib/offerCostBasis.test.ts`
+
+**Kontext:** Spiegelt `get_offer_cost_basis` für unsaved Editor-Positionen. Muss dieselben Zahlen liefern (Paritätstest).
+
+- [ ] **Step 1: Failing test schreiben**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { computeOfferCostBasis } from './offerCostBasis';
+
+const rate = 40;
+
+describe('computeOfferCostBasis', () => {
+  it('rechnet Erlös, Kosten und Marge bei vollständiger Basis', () => {
+    const r = computeOfferCostBasis(
+      [{ quantity: 10, unit_price_net: 85, planned_hours_item: 10, material_purchase_cost: 200 }],
+      rate,
+    );
+    expect(r.revenue).toBe(850);
+    expect(r.cost).toBe(600);
+    expect(r.marginPct).toBeCloseTo(29.41, 2);
+    expect(r.isComplete).toBe(true);
+  });
+
+  it('markiert fehlende Kosten als unvollständig, Kosten/Marge null', () => {
+    const r = computeOfferCostBasis(
+      [{ quantity: 1, unit_price_net: 100, planned_hours_item: null, material_purchase_cost: null }],
+      rate,
+    );
+    expect(r.revenue).toBe(100);
+    expect(r.cost).toBeNull();
+    expect(r.marginPct).toBeNull();
+    expect(r.isComplete).toBe(false);
+  });
+
+  it('0 Stunden vom Nutzer zählt als bekannt (reine Materialposition)', () => {
+    const r = computeOfferCostBasis(
+      [{ quantity: 1, unit_price_net: 100, planned_hours_item: 0, material_purchase_cost: 50 }],
+      rate,
+    );
+    expect(r.cost).toBe(50);
+    expect(r.isComplete).toBe(true);
+  });
+
+  it('ohne Kostensatz ist die Basis unvollständig', () => {
+    const r = computeOfferCostBasis(
+      [{ quantity: 1, unit_price_net: 100, planned_hours_item: 2, material_purchase_cost: 0 }],
+      null,
+    );
+    expect(r.cost).toBeNull();
+    expect(r.isComplete).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Test laufen lassen — muss fehlschlagen**
+
+Run: `npx vitest run src/lib/offerCostBasis.test.ts`
+Expected: FAIL („computeOfferCostBasis is not a function").
+
+- [ ] **Step 3: Implementierung schreiben**
+
+```ts
+export interface OfferCostItem {
+  quantity: number | null;
+  unit_price_net: number | null;
+  planned_hours_item: number | null;
+  material_purchase_cost: number | null;
+}
+
+export interface OfferCostBasis {
+  revenue: number;
+  cost: number | null;
+  marginPct: number | null;
+  isComplete: boolean;
+}
+
+const itemKnown = (i: OfferCostItem) =>
+  i.planned_hours_item != null || i.material_purchase_cost != null;
+
+export function computeOfferCostBasis(
+  items: OfferCostItem[],
+  costRate: number | null,
+): OfferCostBasis {
+  const revenue = items.reduce(
+    (s, i) => s + (i.quantity ?? 0) * (i.unit_price_net ?? 0),
+    0,
+  );
+  const complete =
+    items.length > 0 && costRate != null && items.every(itemKnown);
+
+  if (!complete) {
+    return { revenue, cost: null, marginPct: null, isComplete: false };
+  }
+  const cost = items.reduce(
+    (s, i) =>
+      s + (i.planned_hours_item ?? 0) * costRate + (i.material_purchase_cost ?? 0),
+    0,
+  );
+  const marginPct = revenue > 0
+    ? Math.round(((revenue - cost) / revenue) * 10000) / 100
+    : null;
+  return { revenue, cost, marginPct, isComplete: true };
+}
+```
+
+- [ ] **Step 4: Test laufen lassen — muss bestehen**
+
+Run: `npx vitest run src/lib/offerCostBasis.test.ts`
+Expected: PASS (4 Tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/offerCostBasis.ts src/lib/offerCostBasis.test.ts
+git commit -m "feat: TS-Rechnung fuer Angebots-Soll-Kostenbasis (Live-Marge)"
+```
+
+---
+
+## Task 3: Live-Marge im Angebots-Editor
+
+**Files:**
+- Modify: `src/components/offers/OfferSummaryCard.tsx`
+
+**Kontext:** `OfferSummaryCard` zeigt bereits Angebotssummen. Ergänze Kosten + Marge auf Basis von Task 2. Der Kostensatz wird als Prop übergeben (der aufrufende Dialog kennt die Firma; Laden des Satzes ist Sache des Dialogs — hier nur Prop). Positionen kommen aus dem bestehenden Editor-State.
+
+- [ ] **Step 1: Failing test schreiben**
+
+`src/components/offers/OfferSummaryCard.test.tsx`:
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { OfferSummaryCard } from './OfferSummaryCard';
+
+describe('OfferSummaryCard Marge', () => {
+  it('zeigt Marge bei vollständiger Kostenbasis', () => {
+    render(<OfferSummaryCard
+      items={[{ quantity: 10, unit_price_net: 85, planned_hours_item: 10, material_purchase_cost: 200 }] as any}
+      costRate={40} />);
+    expect(screen.getByText(/29,4/)).toBeInTheDocument();
+  });
+
+  it('warnt bei unvollständiger Kostenbasis', () => {
+    render(<OfferSummaryCard
+      items={[{ quantity: 1, unit_price_net: 100, planned_hours_item: null, material_purchase_cost: null }] as any}
+      costRate={40} />);
+    expect(screen.getByText(/Kosten fehlen|unvollständig/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Test laufen lassen — muss fehlschlagen**
+
+Run: `npx vitest run src/components/offers/OfferSummaryCard.test.tsx`
+Expected: FAIL (Props/Text fehlen).
+
+- [ ] **Step 3: OfferSummaryCard erweitern**
+
+Neue optionale Props `items` und `costRate`; darunter Block: `const basis = computeOfferCostBasis(items ?? [], costRate ?? null);`. Anzeige:
+- „Kosten (Soll): {formatCurrency(basis.cost)}" wenn `basis.cost != null`.
+- „Marge: {basis.marginPct?.toFixed(1)} %" wenn `basis.marginPct != null`.
+- sonst Hinweis „Marge unvollständig — Kosten fehlen bei n Positionen" (n = Positionen mit `planned_hours_item == null && material_purchase_cost == null`).
+Bestehende Erlös-/Summenanzeige unverändert lassen. Import `computeOfferCostBasis` aus `@/lib/offerCostBasis`, `formatCurrency` aus dem im File bereits genutzten Helper.
+
+- [ ] **Step 4: Test laufen lassen + Verdrahtung im Dialog**
+
+Run: `npx vitest run src/components/offers/OfferSummaryCard.test.tsx` → PASS.
+Dann in `AddOfferDialog.tsx` / `EditOfferDialog.tsx` `items={items}` und `costRate={costRate}` an `OfferSummaryCard` übergeben. `costRate` lädt der Dialog per bestehendem Service-Muster (Query auf aktive `amge_calculations.lohn_mit_agk`; wenn nicht vorhanden `null`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/offers/OfferSummaryCard.tsx src/components/offers/OfferSummaryCard.test.tsx src/components/AddOfferDialog.tsx src/components/EditOfferDialog.tsx
+git commit -m "feat: Live-Marge im Angebots-Editor"
+```
+
+---
+
+## Task 4: Paritätstest TS ↔ SQL
+
+**Files:**
+- Modify: `src/lib/offerCostBasis.test.ts`
+
+**Kontext:** Sichert, dass TS-Rechnung und SQL-Funktion dieselben Zahlen liefern. Da die SQL-Funktion nicht aus Vitest heraus aufrufbar ist, wird die Parität über eine dokumentierte Fixture-Tabelle geprüft: dieselben Eingaben, dieselben erwarteten Zahlen wie im SQL-Test aus Task 1 Step 3/4.
+
+- [ ] **Step 1: Paritäts-Fixture als Test ergänzen**
+
+```ts
+// Muss deckungsgleich mit dem SQL-Test in Task 1 (get_offer_cost_basis) sein.
+it('Parität mit get_offer_cost_basis (SQL) für die Referenz-Fixture', () => {
+  const r = computeOfferCostBasis(
+    [{ quantity: 10, unit_price_net: 85, planned_hours_item: 10, material_purchase_cost: 200 }],
+    40,
+  );
+  // Erwartungswerte identisch zum SQL-Ergebnis: revenue 850, cost 600, margin 29.41
+  expect(r.revenue).toBe(850);
+  expect(r.cost).toBe(600);
+  expect(r.marginPct).toBeCloseTo(29.41, 2);
+});
+```
+
+- [ ] **Step 2: Test laufen lassen**
+
+Run: `npx vitest run src/lib/offerCostBasis.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/offerCostBasis.test.ts
+git commit -m "test: Paritaet TS-Rechnung gegen SQL-Kostenbasis"
+```
+
+---
+
+## Task 5: Budget → Projekt ohne Freitext-Marker
+
+**Files:**
+- Create: `supabase/migrations/20260722181000_accept_offer_drop_description_markers.sql`
+
+**Kontext:** `accept_offer_and_create_project` schreibt derzeit Planwerte als Text (`'planned_hours: ' || ...`) in `project.description`. Das Budget ist ab jetzt der eingefrorene `offer_targets`-Snapshot (über `offers.project_id` erreichbar). `project.budget` bleibt der Erlöswert.
+
+- [ ] **Step 1: Prüfen, ob Code die Text-Marker liest**
+
+Run: `git grep -nE "planned_hours:|accepted_offer_id:|target_revenue:|target_margin:" -- src/`
+Expected: Wenn Treffer außerhalb der Migrationen → im selben Task mit auf den Snapshot umstellen. Wenn keine Treffer → Marker sind reine Altlast, gefahrlos entfernbar.
+
+- [ ] **Step 2: RPC ohne Marker neu definieren**
+
+Migration: `CREATE OR REPLACE FUNCTION public.accept_offer_and_create_project(...)` — identisch zur aktuellen Live-Definition (kanonisches Statusmodell, `status='planned'`, `workflow_stage='ordered'`), aber `v_description` wird zu `v_offer.project_name` bzw. leer statt der `CONCAT_WS`-Markerliste. `budget := COALESCE(v_offer.snapshot_net_total, v_targets.snapshot_target_revenue)` bleibt. Die vollständige aktuelle Definition vor dem Editieren aus der DB ziehen (`pg_get_functiondef`), nur den `v_description`-Block ändern — Muster wie in der bisherigen Repo-Historie.
+
+- [ ] **Step 3: Lokal anwenden und Kette testen**
+
+Run: `npx supabase db reset` + der bestehende Ketten-Testablauf (Angebot anlegen → sent → accept). Prüfen: `projects.description` enthält keine `planned_hours:`-Marker mehr; `projects.budget` gesetzt; das akzeptierte Angebot hat einen `offer_targets`-Snapshot.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add supabase/migrations/20260722181000_accept_offer_drop_description_markers.sql
+git commit -m "refactor: Projektbudget aus offer_targets-Snapshot statt Freitext-Markern"
+```
+
+---
+
+## Task 6: Verifikation der Gesamtkette
+
+- [ ] **Step 1: Vollständiger Testlauf**
+
+Run: `npx vitest run` → alle grün. `npm run typecheck` → keine neuen Fehler gegen Basislinie.
+
+- [ ] **Step 2: E2E-Kette lokal**
+
+`npx supabase db reset`, dann Angebot mit vollständigen Kosten anlegen → senden → `offer_targets`-Snapshot geprüft (Erlös/Kosten/Marge/`cost_rate_snapshot` gesetzt) → annehmen → Projekt mit Budget, ohne Text-Marker. Zweites Angebot mit unvollständigen Kosten → senden → nur Erlös-Snapshot, Kosten/Marge NULL.
+
+- [ ] **Step 3: Branch abschließen**
+
+`superpowers:finishing-a-development-branch` zur Integration (PR gegen `main`).
+
+---
+
+## Risiken / Hinweise
+
+- **`accept_offer_and_create_project`** wurde in diesem Repo mehrfach über die API angewandt (neue Zeitstempel) — Dateiname der neuen Migration ggf. nach Anwendung an die Remote-Version angleichen.
+- **Ein Kostensatz für alle Rollen** (Mittellohn) ist bewusst MVP; rollenspezifische Sätze sind Folge-Spec.
+- **Zwei Formel-Implementierungen** (SQL autoritativ, TS für Live-Anzeige) sind durch den Paritätstest (Task 4) gekoppelt — bei Formeländerungen beide anpassen.

--- a/docs/superpowers/specs/2026-07-22-soll-kostenbasis-design.md
+++ b/docs/superpowers/specs/2026-07-22-soll-kostenbasis-design.md
@@ -1,0 +1,123 @@
+# Soll-Kostenbasis für Angebote und Projekte
+
+**Status:** Entwurf · **Datum:** 2026-07-22 · **Kontext:** erster Baustein des Fachkonzepts „Vor- und Nachkalkulation" (HandwerkOS_Vor_und_Nachkalkulation_Konzept.docx)
+
+## Problem
+
+HandwerkOS erfasst heute die **Verkaufsseite** (was der Kunde zahlt), aber nahezu keine **Kostenseite** (was es den Betrieb kostet). Belegt am Produktionsstand (2026-07-22):
+
+- 13 `offer_items`: 11 mit Verkaufspreis, **0 mit `planned_hours_item`, 0 mit `material_purchase_cost`**.
+- `offer_targets`: selbst bei akzeptierten Angeboten sind die Plan-Felder leer — das Formular ist optional („internal only", keine Validierung) und wird übersprungen.
+- `accept_offer_and_create_project` schreibt Planwerte als **Freitext-Marker in `project.description`** (`planned_hours: X`), nicht strukturiert.
+
+Folge: Es gibt **keine belastbare Soll-Kostenbasis** pro Projekt. Jede spätere Nachkalkulation (Soll-Ist, Margenwarnung, Prognose) hätte kein Budget, gegen das sie vergleichen könnte.
+
+Eine Vor-/Nachkalkulation ist im Kern eine **Kostendisziplin**. Der erste Schritt ist deshalb nicht ein Reporting-Dashboard, sondern verlässliche **Kosten-Eingaben** zu gewinnen.
+
+## Ziel und Abgrenzung
+
+**Ziel:** Pro Angebot entsteht — aus Daten, die der Nutzer ohnehin eingibt — eine strukturierte, eingefrorene Soll-Kostenbasis (Planstunden, Plankosten, Zielmarge), die bei Annahme als Projektbudget übernommen wird.
+
+**In Scope (diese Spec):**
+- Kostensatz-Auflösung je Firma aus vorhandener Betriebskalkulation.
+- Kostenableitung je Angebotsposition (Stunden × Satz + Material).
+- Sichtbare Live-Marge im Angebots-Editor.
+- Einfrieren der Soll-Werte in `offer_targets` beim Erstversand/Annahme.
+- Strukturierte Budget-Übernahme ins Projekt (Ablösung der Freitext-Marker).
+
+**Ausdrücklich NICHT in Scope (jeweils eigene Folge-Spec):**
+- Ist-Lohnkosten-Quelle (Versöhnung `time_entries` ↔ `timesheets`, Kostensatz-Snapshot bei Zeitbuchung).
+- Material-Ist an Artikelstamm gebunden.
+- Nachkalkulations-Dashboard, Endkostenprognose, automatische Warnungen.
+- Lernendes System / KI-Zeitschätzung.
+- Leistungspakete / Stücklisten je Position (`calculation_item_components`).
+
+## Bestehendes, das wiederverwendet wird (nicht ersetzt)
+
+| Zweck | Vorhandenes Artefakt |
+|---|---|
+| Betriebs-/Lohnkalkulation, Vollkostensatz | `amge_calculations` — aktive Zeile liefert `lohn_mit_agk` (Vollkosten/h, Kostenseite) und `verrechnungslohn` (Verkaufsseite). Aktueller Ist-Wert der Testfirma: 40,39 € Kosten vs. 43,22 € Verkauf. |
+| Plan je Position | `offer_items.planned_hours_item`, `offer_items.material_purchase_cost` |
+| Verkaufswert je Position | `offer_items.quantity`, `offer_items.unit_price_net` |
+| Eingefrorene Soll-Werte | `offer_targets.snapshot_target_revenue / snapshot_target_cost / snapshot_target_margin / snapshot_created_at` |
+| Angebot↔Projekt-Verknüpfung | `offers.project_id` (bei Annahme gesetzt) |
+
+## Entwurf
+
+### 1. Kostensatz-Auflösung
+
+Eine reine Funktion `resolveLaborCostRate(companyId, atDate)`:
+
+1. aktive `amge_calculations` der Firma, gültig zum `atDate` (`valid_from <= atDate <= valid_until` bzw. offen) → `lohn_mit_agk`.
+2. Fallback: `company_ai_settings.default_hourly_rate`.
+3. Sonst: definierter Fehler „kein Kostensatz hinterlegt" (die UI verlangt dann Ersteinrichtung der Betriebskalkulation).
+
+Kein neues Schema. `lohn_mit_agk` ist bewusst die **Kostenseite** (vor Wagnis+Gewinn) — die §3.1-Trennung Kosten- vs. Verkaufspreis.
+
+### 2. Kostenableitung je Position
+
+Reine Berechnung, keine Persistenz zusätzlicher Positionsfelder:
+
+- `positionPlannedCost = planned_hours_item × costRate + material_purchase_cost`
+- `positionSalesValue  = quantity × unit_price_net`
+- Eine Position hat eine **bekannte Kostenbasis**, wenn `planned_hours_item IS NOT NULL` **oder** `material_purchase_cost IS NOT NULL`. NULL bei beiden = **„Kosten fehlen"** (nicht 0 €), damit die Position nicht als 100 % Marge durchschlägt. `0` ist ein gültiger, vom Nutzer gesetzter Wert (z. B. reine Materialposition) und zählt als bekannt.
+- **Kostenbasis vollständig** = alle Positionen des Angebots haben eine bekannte Kostenbasis.
+
+### 3. Live-Marge im Angebots-Editor (Teil B)
+
+Im bestehenden Angebots-Editor (`AddOfferDialog` / `OfferSummaryCard`) laufend anzeigen:
+- Summe Verkauf, Summe Kosten, **Marge %** (nach §5 als Marge `= (Verkauf − Kosten)/Verkauf`, klar getrennt vom Aufschlag).
+- Deutlicher Hinweis, wenn Positionen ohne Kostenansatz enthalten sind („Marge unvollständig — n Positionen ohne Kosten").
+
+Ziel: Das Überspringen der Kostenerfassung wird sichtbar und teuer, statt still möglich.
+
+### 4. Einfrieren beim Versand/Annahme
+
+Beim Erstversand (Übergang draft→sent, dort wo bereits die echte Nummer gezogen wird) **und** bei Annahme werden die Soll-Werte eingefroren:
+- `snapshot_target_revenue = Σ positionSalesValue` — **immer** gesetzt (Erlös ist vollständig bekannt).
+- `snapshot_target_cost` und `snapshot_target_margin` werden **nur gesetzt, wenn die Kostenbasis vollständig ist** (jede Position hat eine bekannte Kostenbasis). Ist sie unvollständig, bleiben beide `NULL` — es wird **keine irreführende Kostensumme fabriziert** (eine fehlende Position würde die Kosten zu niedrig und die Marge zu hoch erscheinen lassen). Das Projekt hat dann ein Erlös-Budget, aber bewusst kein Kosten-Budget.
+- `snapshot_created_at = now()`.
+- **Neu:** `offer_targets.cost_rate_snapshot NUMERIC` — der zum Einfrierzeitpunkt verwendete Kostensatz (40,39), nur gesetzt wenn auch der Kosten-Snapshot gesetzt wird. Macht die Basis reproduzierbar (§10). **Einzige Schema-Änderung dieser Spec.**
+
+Der Versand wird **nicht** an vollständigen Kosten gehindert — Senden ist eine Kunden-/Verkaufsaktion und darf nicht an interner Kalkulationsdisziplin scheitern. Die Vollständigkeit wird im Editor (Abschnitt 3) sichtbar gemacht, nicht erzwungen.
+
+Bereits eingefrorene Snapshots werden nicht überschrieben (GoBD/§10): erneutes Senden erzeugt keine stille Änderung der eingefrorenen Basis.
+
+### 5. Budget → Projekt
+
+`accept_offer_and_create_project` wird angepasst:
+- **entfällt:** Planwerte als Freitext in `project.description`.
+- Das Projektbudget ist ab jetzt der eingefrorene `offer_targets`-Snapshot des akzeptierten Angebots (erreichbar über `offers.project_id`). `project.budget` bleibt der Erlös-Wert für die bestehende Anzeige.
+- Bekannte, akzeptierte Grenze: Projekte ohne akzeptiertes Angebot (manuell / aus Auftrag) haben zunächst keine Soll-Basis. Manuelle Budgeterfassung ist Folge-Spec.
+
+### Schema-Änderungen (Minimum)
+
+Eine Migration:
+```sql
+ALTER TABLE public.offer_targets
+  ADD COLUMN IF NOT EXISTS cost_rate_snapshot NUMERIC;
+COMMENT ON COLUMN public.offer_targets.cost_rate_snapshot IS
+  'Interner Vollkosten-Stundensatz (amge_calculations.lohn_mit_agk) zum Einfrierzeitpunkt. Macht die eingefrorene Soll-Kostenbasis reproduzierbar.';
+```
+Keine neuen Tabellen. `create_offer_with_targets` bleibt strukturell; die RPC/Service-Schicht befüllt zusätzlich die Snapshot-Felder beim Einfrieren.
+
+## Berechnungs-Definitionen (verbindlich)
+
+- **Marge** `= (Verkauf − Kosten) / Verkauf` (nicht Aufschlag `= (Verkauf − Kosten)/Kosten`). Die UI benennt beide getrennt (§5).
+- **Kostensatz** ist die Kostenseite `lohn_mit_agk`, nie `verrechnungslohn`.
+- **Fehlende Kosten** propagieren als „unbekannt", nicht als 0 — eine Angebotssumme mit unvollständigen Kosten zeigt keine irreführende Marge.
+
+## Testfälle
+
+1. `resolveLaborCostRate`: aktive AMGE → `lohn_mit_agk`; keine AMGE aber `default_hourly_rate` → Fallback; keins von beidem → definierter Fehler; Gültigkeitsdatum wählt die richtige Zeile.
+2. Kostenableitung: `h×Satz + Material` je Position; Position ohne Stunden → „Kosten fehlen", nicht 0.
+3. Marge vs. Aufschlag: dieselben Zahlen ergeben unterschiedliche Prozente; die richtige Formel wird angezeigt.
+4. Einfrieren: bei vollständiger Kostenbasis werden `snapshot_target_cost/-margin/cost_rate_snapshot` gesetzt; bei unvollständiger Basis bleibt der Erlös-Snapshot gesetzt, Kosten/Marge aber `NULL`; erneutes Senden überschreibt einen bestehenden Snapshot nicht.
+5. Budget-Übernahme: akzeptiertes Angebot → Projekt trägt strukturiertes Budget; kein Freitext-Marker mehr in `description`.
+6. Grenze: Projekt ohne Angebot → kein Budget, kein Fehler.
+
+## Offene Punkte / Risiken
+
+- **Ein Kostensatz für alle Rollen:** `amge_calculations` liefert einen Mittellohn-Vollkostensatz, keine rollenspezifischen Sätze (Geselle/Azubi/Meister). Für das MVP bewusst ein Satz; rollenspezifische `labor_rate_versions` sind Folge-Spec.
+- **Rückwirkung auf bestehende Angebote:** Alt-Angebote ohne Kostenansatz zeigen „Kosten fehlen". Kein Backfill — die Kostenbasis entsteht ab Einführung vorwärts.
+- **`accept_offer_and_create_project`** wurde in diesem Repo mehrfach angefasst (zuletzt kanonisches Statusmodell). Änderung dort sorgfältig gegen die bestehenden E2E-/Kettentests prüfen.

--- a/src/components/AddOfferDialog.tsx
+++ b/src/components/AddOfferDialog.tsx
@@ -27,6 +27,7 @@ import { useToast } from '@/hooks/use-toast';
 import { supabase } from '@/integrations/supabase/client';
 import { OfferItemsEditor, OfferTargetsForm, OfferSummaryCard } from '@/components/offers';
 import { useCreateOffer, useEmployees } from '@/hooks/useApi';
+import { useSupabaseAuth } from '@/hooks/useSupabaseAuth';
 import {
   OfferCreate,
   OfferItemCreate,
@@ -82,11 +83,13 @@ export function AddOfferDialog({
   const { toast } = useToast();
   const createOfferMutation = useCreateOffer();
   const { data: employeesData } = useEmployees();
+  const { companyId } = useSupabaseAuth();
 
   // Form state
   const [activeTab, setActiveTab] = useState('basics');
   const [customers, setCustomers] = useState<Customer[]>([]);
   const [loadingCustomers, setLoadingCustomers] = useState(false);
+  const [costRate, setCostRate] = useState<number | null>(null);
 
   // Offer data
   const [offerData, setOfferData] = useState<OfferCreate>({
@@ -114,6 +117,32 @@ export function AddOfferDialog({
       loadCustomers();
     }
   }, [isOpen]);
+
+  // Load internen Vollkostensatz aus der aktiven Betriebskalkulation (für Live-Marge)
+  useEffect(() => {
+    if (!isOpen || !companyId) {
+      return;
+    }
+    let cancelled = false;
+    const loadCostRate = async () => {
+      const { data } = await supabase
+        .from('amge_calculations')
+        .select('lohn_mit_agk')
+        .eq('company_id', companyId)
+        .eq('is_active', true)
+        .order('valid_from', { ascending: false, nullsFirst: false })
+        .limit(1)
+        .maybeSingle();
+
+      if (!cancelled) {
+        setCostRate(data?.lohn_mit_agk ?? null);
+      }
+    };
+    loadCostRate();
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, companyId]);
 
   // Pre-fill customer if preselected
   useEffect(() => {
@@ -470,7 +499,7 @@ export function AddOfferDialog({
                 </div>
               </div>
               <div>
-                <OfferSummaryCard items={items} />
+                <OfferSummaryCard items={items} costRate={costRate} />
               </div>
             </div>
           </TabsContent>

--- a/src/components/EditOfferDialog.tsx
+++ b/src/components/EditOfferDialog.tsx
@@ -24,6 +24,8 @@ import { CalendarIcon, Loader2, Lock } from 'lucide-react';
 import { format } from 'date-fns';
 import { de } from 'date-fns/locale';
 import { useToast } from '@/hooks/use-toast';
+import { supabase } from '@/integrations/supabase/client';
+import { useSupabaseAuth } from '@/hooks/useSupabaseAuth';
 import { OfferItemsEditor, OfferTargetsForm, OfferSummaryCard } from '@/components/offers';
 import {
   useOffer,
@@ -57,6 +59,7 @@ export function EditOfferDialog({
 }: EditOfferDialogProps) {
   const { toast } = useToast();
   const { data: employeesData } = useEmployees();
+  const { companyId } = useSupabaseAuth();
 
   // Queries
   const { data: offer, isLoading: offerLoading } = useOffer(offerId || '', {
@@ -80,6 +83,7 @@ export function EditOfferDialog({
   const [targets, setTargets] = useState<OfferTargetCreate>({});
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [isSaving, setIsSaving] = useState(false);
+  const [costRate, setCostRate] = useState<number | null>(null);
 
   // Load offer data when dialog opens
   useEffect(() => {
@@ -118,6 +122,32 @@ export function EditOfferDialog({
       setItems(offerItems);
     }
   }, [offerItems]);
+
+  // Load internen Vollkostensatz aus der aktiven Betriebskalkulation (für Live-Marge)
+  useEffect(() => {
+    if (!isOpen || !companyId) {
+      return;
+    }
+    let cancelled = false;
+    const loadCostRate = async () => {
+      const { data } = await supabase
+        .from('amge_calculations')
+        .select('lohn_mit_agk')
+        .eq('company_id', companyId)
+        .eq('is_active', true)
+        .order('valid_from', { ascending: false, nullsFirst: false })
+        .limit(1)
+        .maybeSingle();
+
+      if (!cancelled) {
+        setCostRate(data?.lohn_mit_agk ?? null);
+      }
+    };
+    loadCostRate();
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, companyId]);
 
   const isLocked = offer?.is_locked || offer?.status !== 'draft';
 
@@ -484,7 +514,7 @@ export function EditOfferDialog({
                     </div>
                   </div>
                   <div>
-                    <OfferSummaryCard items={items as OfferItem[]} />
+                    <OfferSummaryCard items={items as OfferItem[]} costRate={costRate} />
                   </div>
                 </div>
               </TabsContent>

--- a/src/components/offers/OfferSummaryCard.test.tsx
+++ b/src/components/offers/OfferSummaryCard.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { OfferSummaryCard } from './OfferSummaryCard';
+
+describe('OfferSummaryCard Marge', () => {
+  it('zeigt Marge bei vollständiger Kostenbasis', () => {
+    render(<OfferSummaryCard
+      items={[{ quantity: 10, unit_price_net: 85, planned_hours_item: 10, material_purchase_cost: 200 }] as any}
+      costRate={40} />);
+    expect(screen.getByText(/29,4|29\.4/)).toBeInTheDocument();
+  });
+
+  it('warnt bei unvollständiger Kostenbasis', () => {
+    render(<OfferSummaryCard
+      items={[{ quantity: 1, unit_price_net: 100, planned_hours_item: null, material_purchase_cost: null }] as any}
+      costRate={40} />);
+    expect(screen.getByText(/Kosten fehlen|unvollständig/i)).toBeInTheDocument();
+  });
+
+  it('warnt fehlenden Kostensatz separat von fehlenden Positionsdaten', () => {
+    render(<OfferSummaryCard
+      items={[{ quantity: 10, unit_price_net: 85, planned_hours_item: 10, material_purchase_cost: 200 }] as any}
+      costRate={null} />);
+    expect(screen.getByText(/Kostensatz/i)).toBeInTheDocument();
+    expect(screen.queryByText(/0 Positionen/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/offers/OfferSummaryCard.test.tsx
+++ b/src/components/offers/OfferSummaryCard.test.tsx
@@ -24,4 +24,13 @@ describe('OfferSummaryCard Marge', () => {
     expect(screen.getByText(/Kostensatz/i)).toBeInTheDocument();
     expect(screen.queryByText(/0 Positionen/i)).not.toBeInTheDocument();
   });
+
+  it('zeigt weder Marge noch Warnung, wenn der Aufrufer costRate gar nicht übergibt', () => {
+    render(<OfferSummaryCard
+      items={[{ quantity: 10, unit_price_net: 85, planned_hours_item: 10, material_purchase_cost: 200 }] as any}
+    />);
+    expect(screen.queryByText(/Marge/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Kostensatz/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Positionen/i)).not.toBeInTheDocument();
+  });
 });

--- a/src/components/offers/OfferSummaryCard.tsx
+++ b/src/components/offers/OfferSummaryCard.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
 import { OfferItem } from '@/types/offer';
+import { computeOfferCostBasis } from '@/lib/offerCostBasis';
 
 interface OfferSummaryCardProps {
   items: OfferItem[];
@@ -13,6 +14,8 @@ interface OfferSummaryCardProps {
     vat_amount: number | null;
     gross_total: number | null;
   };
+  /** Interner Vollkostensatz (€/Std., z.B. amge_calculations.lohn_mit_agk) für die Live-Marge. */
+  costRate?: number | null;
   className?: string;
 }
 
@@ -23,11 +26,19 @@ function formatCurrency(value: number): string {
   }).format(value);
 }
 
+function formatPercent(value: number): string {
+  return new Intl.NumberFormat('de-DE', {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  }).format(value);
+}
+
 export function OfferSummaryCard({
   items,
   vatRate = 19,
   discountPercent = 0,
   snapshotTotals,
+  costRate = null,
   className = '',
 }: OfferSummaryCardProps) {
   // Calculate from items if no snapshot
@@ -55,6 +66,11 @@ export function OfferSummaryCard({
   const optionalTotal = items
     .filter(item => item.is_optional)
     .reduce((sum, item) => sum + item.quantity * item.unit_price_net, 0);
+
+  const costBasis = computeOfferCostBasis(items, costRate);
+  const itemsMissingCostBasis = items.filter(
+    item => item.planned_hours_item == null && item.material_purchase_cost == null
+  ).length;
 
   return (
     <Card className={className}>
@@ -90,6 +106,31 @@ export function OfferSummaryCard({
           <span>Gesamtsumme (brutto)</span>
           <span>{formatCurrency(totals.gross_total || 0)}</span>
         </div>
+
+        <Separator />
+
+        {costBasis.cost != null && (
+          <div className="flex justify-between text-sm">
+            <span className="text-muted-foreground">Kosten (Soll)</span>
+            <span>{formatCurrency(costBasis.cost)}</span>
+          </div>
+        )}
+
+        {costBasis.marginPct != null ? (
+          <div className="flex justify-between text-sm font-medium">
+            <span className="text-muted-foreground">Marge</span>
+            <span>{formatPercent(costBasis.marginPct)} %</span>
+          </div>
+        ) : items.length === 0 ? null : costRate == null ? (
+          <p className="text-sm text-amber-600">
+            Kein interner Kostensatz hinterlegt — Marge nicht berechenbar
+          </p>
+        ) : itemsMissingCostBasis > 0 ? (
+          <p className="text-sm text-amber-600">
+            Marge unvollständig — Kosten fehlen bei {itemsMissingCostBasis}{' '}
+            {itemsMissingCostBasis === 1 ? 'Position' : 'Positionen'}
+          </p>
+        ) : null}
 
         {optionalTotal > 0 && (
           <>

--- a/src/components/offers/OfferSummaryCard.tsx
+++ b/src/components/offers/OfferSummaryCard.tsx
@@ -38,7 +38,7 @@ export function OfferSummaryCard({
   vatRate = 19,
   discountPercent = 0,
   snapshotTotals,
-  costRate = null,
+  costRate,
   className = '',
 }: OfferSummaryCardProps) {
   // Calculate from items if no snapshot
@@ -67,7 +67,7 @@ export function OfferSummaryCard({
     .filter(item => item.is_optional)
     .reduce((sum, item) => sum + item.quantity * item.unit_price_net, 0);
 
-  const costBasis = computeOfferCostBasis(items, costRate);
+  const costBasis = computeOfferCostBasis(items, costRate ?? null);
   const itemsMissingCostBasis = items.filter(
     item => item.planned_hours_item == null && item.material_purchase_cost == null
   ).length;
@@ -121,7 +121,7 @@ export function OfferSummaryCard({
             <span className="text-muted-foreground">Marge</span>
             <span>{formatPercent(costBasis.marginPct)} %</span>
           </div>
-        ) : items.length === 0 ? null : costRate == null ? (
+        ) : costRate === undefined ? null : items.length === 0 ? null : costRate === null ? (
           <p className="text-sm text-amber-600">
             Kein interner Kostensatz hinterlegt — Marge nicht berechenbar
           </p>

--- a/src/lib/offerCostBasis.test.ts
+++ b/src/lib/offerCostBasis.test.ts
@@ -15,6 +15,22 @@ describe('computeOfferCostBasis', () => {
     expect(r.isComplete).toBe(true);
   });
 
+  // Parität zur SQL-Funktion get_offer_cost_basis (Migration 20260722180000).
+  // Die Erwartungswerte sind KEINE Handrechnung, sondern die real gemessene
+  // Ausgabe der SQL-Funktion gegen dieselben Eingaben (lokale DB, 2026-07-22):
+  //   revenue 850.00000 | cost 603.9000 | margin_pct 28.95 | cost_rate 40.39 | complete t
+  // Weichen beide Seiten voneinander ab, ist eine der Formeln geändert worden.
+  it('liefert dieselben Zahlen wie die SQL-Funktion get_offer_cost_basis', () => {
+    const r = computeOfferCostBasis(
+      [{ quantity: 10, unit_price_net: 85, planned_hours_item: 10, material_purchase_cost: 200 }],
+      40.39,
+    );
+    expect(r.revenue).toBe(850);
+    expect(r.cost).toBeCloseTo(603.9, 4);
+    expect(r.marginPct).toBe(28.95);
+    expect(r.isComplete).toBe(true);
+  });
+
   it('markiert fehlende Kosten als unvollständig, Kosten/Marge null', () => {
     const r = computeOfferCostBasis(
       [{ quantity: 1, unit_price_net: 100, planned_hours_item: null, material_purchase_cost: null }],

--- a/src/lib/offerCostBasis.test.ts
+++ b/src/lib/offerCostBasis.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { computeOfferCostBasis } from './offerCostBasis';
+
+const rate = 40;
+
+describe('computeOfferCostBasis', () => {
+  it('rechnet Erlös, Kosten und Marge bei vollständiger Basis', () => {
+    const r = computeOfferCostBasis(
+      [{ quantity: 10, unit_price_net: 85, planned_hours_item: 10, material_purchase_cost: 200 }],
+      rate,
+    );
+    expect(r.revenue).toBe(850);
+    expect(r.cost).toBe(600);
+    expect(r.marginPct).toBeCloseTo(29.41, 2);
+    expect(r.isComplete).toBe(true);
+  });
+
+  it('markiert fehlende Kosten als unvollständig, Kosten/Marge null', () => {
+    const r = computeOfferCostBasis(
+      [{ quantity: 1, unit_price_net: 100, planned_hours_item: null, material_purchase_cost: null }],
+      rate,
+    );
+    expect(r.revenue).toBe(100);
+    expect(r.cost).toBeNull();
+    expect(r.marginPct).toBeNull();
+    expect(r.isComplete).toBe(false);
+  });
+
+  it('0 Stunden vom Nutzer zählt als bekannt (reine Materialposition)', () => {
+    const r = computeOfferCostBasis(
+      [{ quantity: 1, unit_price_net: 100, planned_hours_item: 0, material_purchase_cost: 50 }],
+      rate,
+    );
+    expect(r.cost).toBe(50);
+    expect(r.isComplete).toBe(true);
+  });
+
+  it('ohne Kostensatz ist die Basis unvollständig', () => {
+    const r = computeOfferCostBasis(
+      [{ quantity: 1, unit_price_net: 100, planned_hours_item: 2, material_purchase_cost: 0 }],
+      null,
+    );
+    expect(r.cost).toBeNull();
+    expect(r.isComplete).toBe(false);
+  });
+});

--- a/src/lib/offerCostBasis.ts
+++ b/src/lib/offerCostBasis.ts
@@ -1,8 +1,8 @@
 export interface OfferCostItem {
-  quantity: number | null;
-  unit_price_net: number | null;
-  planned_hours_item: number | null;
-  material_purchase_cost: number | null;
+  quantity?: number | null;
+  unit_price_net?: number | null;
+  planned_hours_item?: number | null;
+  material_purchase_cost?: number | null;
 }
 
 export interface OfferCostBasis {

--- a/src/lib/offerCostBasis.ts
+++ b/src/lib/offerCostBasis.ts
@@ -1,0 +1,41 @@
+export interface OfferCostItem {
+  quantity: number | null;
+  unit_price_net: number | null;
+  planned_hours_item: number | null;
+  material_purchase_cost: number | null;
+}
+
+export interface OfferCostBasis {
+  revenue: number;
+  cost: number | null;
+  marginPct: number | null;
+  isComplete: boolean;
+}
+
+const itemKnown = (i: OfferCostItem) =>
+  i.planned_hours_item != null || i.material_purchase_cost != null;
+
+export function computeOfferCostBasis(
+  items: OfferCostItem[],
+  costRate: number | null,
+): OfferCostBasis {
+  const revenue = items.reduce(
+    (s, i) => s + (i.quantity ?? 0) * (i.unit_price_net ?? 0),
+    0,
+  );
+  const complete =
+    items.length > 0 && costRate != null && items.every(itemKnown);
+
+  if (!complete) {
+    return { revenue, cost: null, marginPct: null, isComplete: false };
+  }
+  const cost = items.reduce(
+    (s, i) =>
+      s + (i.planned_hours_item ?? 0) * costRate + (i.material_purchase_cost ?? 0),
+    0,
+  );
+  const marginPct = revenue > 0
+    ? Math.round(((revenue - cost) / revenue) * 10000) / 100
+    : null;
+  return { revenue, cost, marginPct, isComplete: true };
+}

--- a/supabase/migrations/20260722180000_offer_cost_basis.sql
+++ b/supabase/migrations/20260722180000_offer_cost_basis.sql
@@ -1,0 +1,119 @@
+-- Soll-Kostenbasis: Spalte, autoritative Berechnungsfunktion, Freeze-Trigger.
+-- Siehe docs/superpowers/specs/2026-07-22-soll-kostenbasis-design.md
+
+-- 1. Reproduzierbarkeit des eingefrorenen Kostensatzes
+ALTER TABLE public.offer_targets
+  ADD COLUMN IF NOT EXISTS cost_rate_snapshot NUMERIC;
+COMMENT ON COLUMN public.offer_targets.cost_rate_snapshot IS
+  'Interner Vollkosten-Stundensatz (amge_calculations.lohn_mit_agk) zum Einfrierzeitpunkt.';
+
+-- 1b. Ein Angebot hat genau eine Zielzeile. Bisher gab es nur den Primary Key
+--     auf id — ohne UNIQUE(offer_id) scheitert das ON CONFLICT im Freeze-Trigger
+--     unten zur Laufzeit. Tabelle ist leer, der Constraint greift ohne Backfill.
+ALTER TABLE public.offer_targets
+  DROP CONSTRAINT IF EXISTS offer_targets_offer_id_key;
+ALTER TABLE public.offer_targets
+  ADD CONSTRAINT offer_targets_offer_id_key UNIQUE (offer_id);
+
+-- 2. Einzige autoritative Quelle der Soll-Zahlen eines Angebots.
+CREATE OR REPLACE FUNCTION public.get_offer_cost_basis(p_offer_id UUID)
+RETURNS TABLE (
+  revenue      NUMERIC,
+  cost         NUMERIC,
+  margin_pct   NUMERIC,
+  cost_rate    NUMERIC,
+  is_complete  BOOLEAN
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_company_id UUID;
+  v_rate       NUMERIC;
+  v_revenue    NUMERIC;
+  v_cost       NUMERIC;
+  v_complete   BOOLEAN;
+BEGIN
+  SELECT company_id INTO v_company_id FROM public.offers WHERE id = p_offer_id;
+
+  SELECT a.lohn_mit_agk INTO v_rate
+  FROM public.amge_calculations a
+  WHERE a.company_id = v_company_id AND a.is_active
+    AND (a.valid_from IS NULL OR a.valid_from <= CURRENT_DATE)
+    AND (a.valid_until IS NULL OR a.valid_until >= CURRENT_DATE)
+  ORDER BY a.valid_from DESC NULLS LAST
+  LIMIT 1;
+
+  IF v_rate IS NULL THEN
+    SELECT default_hourly_rate INTO v_rate
+    FROM public.company_ai_settings WHERE company_id = v_company_id LIMIT 1;
+  END IF;
+
+  SELECT
+    COALESCE(SUM(oi.quantity * oi.unit_price_net), 0),
+    SUM(COALESCE(oi.planned_hours_item, 0) * COALESCE(v_rate, 0)
+        + COALESCE(oi.material_purchase_cost, 0)),
+    bool_and(oi.planned_hours_item IS NOT NULL OR oi.material_purchase_cost IS NOT NULL)
+  INTO v_revenue, v_cost, v_complete
+  FROM public.offer_items oi
+  WHERE oi.offer_id = p_offer_id;
+
+  IF v_rate IS NULL THEN
+    v_complete := false;
+  END IF;
+
+  v_complete := COALESCE(v_complete, false);
+
+  revenue     := v_revenue;
+  cost        := CASE WHEN v_complete THEN v_cost ELSE NULL END;
+  margin_pct  := CASE WHEN v_complete AND v_revenue > 0
+                      THEN round((v_revenue - v_cost) / v_revenue * 100, 2) ELSE NULL END;
+  cost_rate   := CASE WHEN v_complete THEN v_rate ELSE NULL END;
+  is_complete := v_complete;
+  RETURN NEXT;
+END;
+$$;
+
+-- 3. Freeze-Trigger: friert die Soll-Werte beim Übergang draft->sent/accepted
+--    in offer_targets ein. Trifft beide Versandpfade. Ueberschreibt einen
+--    bestehenden Snapshot NICHT.
+CREATE OR REPLACE FUNCTION public.freeze_offer_target_snapshot()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+DECLARE
+  v_basis RECORD;
+BEGIN
+  IF TG_OP = 'UPDATE' AND OLD.status = 'draft'
+     AND NEW.status IN ('sent', 'accepted') THEN
+
+    SELECT * INTO v_basis FROM public.get_offer_cost_basis(NEW.id);
+
+    INSERT INTO public.offer_targets (offer_id)
+    VALUES (NEW.id)
+    ON CONFLICT (offer_id) DO NOTHING;
+
+    UPDATE public.offer_targets ot
+    SET snapshot_target_revenue = v_basis.revenue,
+        snapshot_target_cost    = v_basis.cost,
+        snapshot_target_margin  = v_basis.margin_pct,
+        cost_rate_snapshot      = v_basis.cost_rate,
+        snapshot_created_at     = NOW(),
+        updated_at              = NOW()
+    WHERE ot.offer_id = NEW.id
+      AND ot.snapshot_created_at IS NULL;
+
+    RETURN NEW;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS freeze_offer_target_snapshot_trigger ON public.offers;
+CREATE TRIGGER freeze_offer_target_snapshot_trigger
+  BEFORE UPDATE ON public.offers
+  FOR EACH ROW
+  EXECUTE FUNCTION public.freeze_offer_target_snapshot();

--- a/supabase/migrations/20260722181000_accept_offer_drop_description_markers.sql
+++ b/supabase/migrations/20260722181000_accept_offer_drop_description_markers.sql
@@ -1,0 +1,91 @@
+-- accept_offer_and_create_project ohne Freitext-Marker in project.description.
+-- Siehe docs/superpowers/specs/2026-07-22-soll-kostenbasis-design.md, Abschnitt 5.
+-- Basis ist die Live-Definition (kanonisches Statusmodell, planned/ordered);
+-- geaendert wurde ausschliesslich die Belegung von v_description.
+-- Geprueft: kein Code liest diese Marker (die anderen description-Marker
+-- [PRECALC:] und [BUDGET:] stammen aus anderem Code und bleiben unberuehrt).
+
+CREATE OR REPLACE FUNCTION public.accept_offer_and_create_project(p_offer_id uuid, p_accepted_by text DEFAULT NULL::text, p_acceptance_note text DEFAULT NULL::text)
+ RETURNS uuid
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_offer public.offers%ROWTYPE;
+  v_targets public.offer_targets%ROWTYPE;
+  v_project_id UUID;
+  v_budget NUMERIC;
+  v_description TEXT;
+BEGIN
+  SELECT * INTO v_offer
+  FROM public.offers
+  WHERE id = p_offer_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Angebot nicht gefunden';
+  END IF;
+
+  IF v_offer.status = 'accepted' AND v_offer.project_id IS NOT NULL THEN
+    RETURN v_offer.project_id;
+  END IF;
+
+  IF v_offer.status NOT IN ('draft', 'sent') THEN
+    RAISE EXCEPTION 'Nur Entwürfe oder versendete Angebote können angenommen werden';
+  END IF;
+
+  IF v_offer.valid_until IS NOT NULL AND v_offer.valid_until::date < CURRENT_DATE THEN
+    RAISE EXCEPTION 'Angebot ist abgelaufen';
+  END IF;
+
+  SELECT * INTO v_targets
+  FROM public.offer_targets
+  WHERE offer_id = p_offer_id
+  LIMIT 1;
+
+  v_project_id := gen_random_uuid();
+  v_budget := COALESCE(v_offer.snapshot_net_total, v_targets.snapshot_target_revenue);
+  -- Nur eine menschenlesbare Herkunftszeile. Die Planwerte standen hier
+  -- frueher als Freitext-Marker ('planned_hours: 12' usw.) — als Soll-Basis
+  -- unbrauchbar und laut ARCHITECTURE_RULES unzulaessig (Magic-Strings in
+  -- Freitextfeldern). Massgeblich ist jetzt der eingefrorene
+  -- offer_targets-Snapshot, erreichbar ueber offers.project_id.
+  v_description := 'Erstellt aus Angebot ' || v_offer.offer_number;
+
+  INSERT INTO public.projects (
+    id, company_id, customer_id, name, status, workflow_stage, description,
+    budget, location, start_date, end_date, work_start_date, work_end_date,
+    workflow_origin_type, workflow_origin_id
+  )
+  VALUES (
+    v_project_id,
+    v_offer.company_id,
+    v_offer.customer_id,
+    v_offer.project_name,
+    'planned',
+    'ordered',
+    v_description,
+    v_budget,
+    v_offer.project_location,
+    v_targets.target_start_date,
+    v_targets.target_end_date,
+    v_targets.target_start_date,
+    v_targets.target_end_date,
+    'offer',
+    v_offer.id
+  );
+
+  UPDATE public.offers
+  SET status = 'accepted',
+      accepted_at = NOW(),
+      accepted_by = p_accepted_by,
+      acceptance_note = p_acceptance_note,
+      is_locked = true,
+      project_id = v_project_id,
+      updated_at = NOW()
+  WHERE id = v_offer.id;
+
+  RETURN v_project_id;
+END;
+$function$;


### PR DESCRIPTION
Erster Baustein aus dem Fachkonzept „Vor- und Nachkalkulation" — bewusst eng geschnitten auf die **Soll-Seite**.

## Problem

HandwerkOS erfasst die Verkaufsseite, aber nahezu keine Kostenseite. Belegt am Produktionsstand:

- 13 `offer_items`: 11 mit Verkaufspreis, **0 mit Planstunden, 0 mit Materialkosten**
- `offer_targets` war komplett leer — das Formular ist optional und wird übersprungen
- Planwerte landeten als Freitext-Marker (`planned_hours: 12`) in `project.description`

Ohne belastbare Soll-Basis kann keine spätere Nachkalkulation gegen irgendetwas vergleichen.

## Lösung

Die Soll-Basis entsteht aus den Positionen, die der Nutzer ohnehin eingibt:

- **`get_offer_cost_basis(offer_id)`** ist die autoritative Quelle: Erlös aus `quantity × unit_price_net`, Kosten aus `planned_hours_item × Vollkostensatz + material_purchase_cost`. Der Satz kommt aus der aktiven `amge_calculations`-Zeile (`lohn_mit_agk` = Kostenseite, **nicht** `verrechnungslohn`).
- **Freeze-Trigger** friert die Werte beim Übergang draft→sent/accepted in `offer_targets` ein — trifft damit beide Versandpfade (Service und `send-offer-email`). Bestehende Snapshots werden nie überschrieben.
- **Live-Marge im Editor** macht fehlende Kosten sichtbar, statt sie still zuzulassen.
- **`accept_offer_and_create_project`** schreibt keine Freitext-Marker mehr; maßgeblich ist der eingefrorene Snapshot.

### Ehrlichkeit statt schöner Zahlen

Ist die Kostenbasis unvollständig (eine Position ohne Stunden **und** ohne Materialkosten, oder gar kein Kostensatz), bleiben Kosten und Marge **NULL** — statt eine zu niedrige Kostensumme und damit eine zu hohe Marge vorzutäuschen. Der Versand wird deshalb aber nicht blockiert: Senden ist eine Verkaufsaktion und darf nicht an interner Kalkulationsdisziplin scheitern.

## Verifikation

Gegen eine von Null aufgebaute Datenbank (`db reset`, 127 Migrationen fehlerfrei):

| Prüfung | Ergebnis |
|---|---|
| `get_offer_cost_basis` (10 Std. à 40,39 € + 200 € Material, VK 850) | 850 / 603,90 / 28,95 % / 40,39 / complete |
| draft→sent | friert ein |
| sent→accepted | überschreibt **nicht** |
| unvollständige Basis | Erlös gesetzt, Kosten/Marge/Satz NULL |
| Annahme → Projekt | Budget 850, `planned`/`ordered`, keine Marker |
| Testsuite | 505/505 |
| Typecheck | Basislinie 956, keine neuen |

Der Paritätstest vergleicht die TS-Rechnung nicht gegen eine Handrechnung, sondern gegen die **real gemessene** SQL-Ausgabe.

## Gefunden und behoben

- `offer_targets` fehlte ein `UNIQUE(offer_id)` — das `ON CONFLICT` im Trigger wäre zur Laufzeit gescheitert
- `trg_calculate_amge` berechnet `lohn_mit_agk` neu; die im Plan notierten Fixture-Werte waren daher unerreichbar (Formel identisch, nur mit echtem Satz)

## Ausdrücklich nicht enthalten

Ist-Seite (Zeitquellen-Versöhnung, Kostensatz-Snapshot bei Zeitbuchung), Material-Ist am Artikelstamm, Nachkalkulations-Dashboard, Prognose, lernendes System, Leistungspakete — jeweils eigene Folge-Specs.

Spec: `docs/superpowers/specs/2026-07-22-soll-kostenbasis-design.md`
Plan: `docs/superpowers/plans/2026-07-22-soll-kostenbasis.md`

**Migrationen sind noch NICHT auf Produktion angewandt.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
